### PR TITLE
resolver: pass loan_pid when resolving item

### DIFF
--- a/invenio_circulation/api.py
+++ b/invenio_circulation/api.py
@@ -37,7 +37,7 @@ class Loan(Record):
         item_attached = data.get("item_pid") and data["item_pid"] != ""
         if ref_builder and item_attached:
             data["item"] = current_app.config["CIRCULATION_ITEM_REF_BUILDER"](
-                data["item_pid"]
+                data["loan_pid"]
             )
         return super(Loan, cls).create(data, id_=id_, **kwargs)
 

--- a/invenio_circulation/utils.py
+++ b/invenio_circulation/utils.py
@@ -33,7 +33,7 @@ def item_exists(item_pid):
 
 
 # NOTE: Its on purpose `ref` and not `$ref` so it doesn't try to resolve
-def item_ref_builder(item_pid):
+def item_ref_builder(loan_pid):
     """Return the $ref for item_pid."""
     raise NotImplementedError(
         "Function is not implemented. \


### PR DESCRIPTION
@BadrAly we have decided to change our way of resolving references.
Previously (using `item_pid`):

`/api/resolver/circulation/items/<item_pid>`

Current (using `loan_pid`):

`/api/resolver/loans/<loan_pid>/item`

This is just to warn you that we need to replace the params when resolving the item attached to a Loan, and we hope it is ok with your and it does not break anything (I don't know if you are using `$ref`).