### PR TITLE
errors: removed logging for TransitionConditionsFailedError

### DIFF
--- a/invenio_circulation/ext.py
+++ b/invenio_circulation/ext.py
@@ -118,7 +118,6 @@ class _Circulation(object):
                 t.execute(loan, **kwargs)
                 return loan
             except TransitionConditionsFailedError as ex:
-                current_app.logger.exception(ex)
                 pass
 
         raise NoValidTransitionAvailableError(


### PR DESCRIPTION
* TransitionConditionsFailedError is used for iterating on available transitions. Logging it might be confusing and unnecessarily pollute sentry logs.