### PR TITLE
global: explicit naming for circulation checkout policy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 Changes
 =======
 
+Version 1.0.0a12 (released 2019-04-17)
+
+- Renamed is_item_available circulation policy to item_can_circulate.
+
 Version 1.0.0a11 (released 2019-03-29)
 
 - Add sort options to search api

--- a/invenio_circulation/api.py
+++ b/invenio_circulation/api.py
@@ -54,13 +54,13 @@ class Loan(Record):
         return record
 
 
-def is_item_available(item_pid):
+def is_item_available_for_checkout(item_pid):
     """Return True if the given item is available for loan, False otherwise."""
     config = current_app.config
-    cfg_item_available = config["CIRCULATION_POLICIES"]["checkout"].get(
-        "item_available"
+    cfg_item_can_circulate = config["CIRCULATION_POLICIES"]["checkout"].get(
+        "item_can_circulate"
     )
-    if not cfg_item_available(item_pid):
+    if not cfg_item_can_circulate(item_pid):
         return False
 
     search = search_by_pid(
@@ -97,7 +97,7 @@ def get_pending_loans_by_doc_pid(document_pid):
 def get_available_item_by_doc_pid(document_pid):
     """Return an item pid available for this document."""
     for item_pid in get_items_by_doc_pid(document_pid):
-        if is_item_available(item_pid):
+        if is_item_available_for_checkout(item_pid):
             return item_pid
     return None
 

--- a/invenio_circulation/config.py
+++ b/invenio_circulation/config.py
@@ -23,7 +23,7 @@ from .transitions.transitions import CreatedToPending, \
     PendingToItemInTransitPickup, ToItemOnLoan
 from .utils import can_be_requested, get_default_extension_duration, \
     get_default_extension_max_count, get_default_loan_duration, \
-    is_item_available, is_loan_duration_valid, item_exists, \
+    is_loan_duration_valid, item_can_circulate, item_exists, \
     item_location_retriever, item_ref_builder, patron_exists
 
 CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT = None
@@ -114,7 +114,7 @@ CIRCULATION_POLICIES = dict(
     checkout=dict(
         duration_default=get_default_loan_duration,
         duration_validate=is_loan_duration_valid,
-        item_available=is_item_available
+        item_can_circulate=item_can_circulate,
     ),
     extension=dict(
         from_end_date=True,

--- a/invenio_circulation/transitions/base.py
+++ b/invenio_circulation/transitions/base.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from flask import current_app
 from invenio_db import db
 
-from ..api import is_item_available
+from ..api import is_item_available_for_checkout
 from ..errors import InvalidLoanStateError, InvalidPermissionError, \
     ItemDoNotMatchError, ItemNotAvailableError, \
     MissingRequiredParameterError, TransitionConditionsFailedError, \
@@ -103,13 +103,13 @@ class Transition(object):
             'CIRCULATION_LOAN_TRANSITIONS_DEFAULT_PERMISSION_FACTORY']
         self.validate_transition_states()
 
-    def ensure_item_is_available(self, loan):
+    def ensure_item_is_available_for_checkout(self, loan):
         """Validate that an item is available."""
         if 'item_pid' not in loan:
             msg = "Item not set for loan with pid '{}'".format(loan.id)
             raise TransitionConstraintsViolationError(description=msg)
 
-        if not is_item_available(loan['item_pid']):
+        if not is_item_available_for_checkout(loan['item_pid']):
             raise ItemNotAvailableError(
                 item_pid=loan['item_pid'], transition=self.dest
             )

--- a/invenio_circulation/transitions/transitions.py
+++ b/invenio_circulation/transitions/transitions.py
@@ -97,7 +97,7 @@ class ToItemOnLoan(Transition):
         """Validate checkout action."""
         super(ToItemOnLoan, self).before(loan, **kwargs)
 
-        self.ensure_item_is_available(loan)
+        self.ensure_item_is_available_for_checkout(loan)
 
         if loan.get('start_date'):
             loan['start_date'] = parse_date(loan['start_date'])

--- a/invenio_circulation/utils.py
+++ b/invenio_circulation/utils.py
@@ -43,10 +43,10 @@ def item_location_retriever(item_pid):
     )
 
 
-def is_item_available(item_pid):
+def item_can_circulate(item_pid):
     """Return if item is available for checkout."""
     raise NotImplementedConfigurationError(
-        config_variable="CIRCULATION_POLICIES.checkout.is_item_available"
+        config_variable="CIRCULATION_POLICIES.checkout.item_can_circulate"
     )
 
 

--- a/invenio_circulation/version.py
+++ b/invenio_circulation/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0a11'
+__version__ = '1.0.0a12'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ from invenio_circulation.pidstore.minters import loan_pid_minter
 from .helpers import create_loan, test_views_permissions_factory
 from .utils import can_be_requested, get_default_extension_duration, \
     get_default_extension_max_count, get_default_loan_duration, \
-    is_item_available, is_loan_duration_valid, item_exists, \
+    is_loan_duration_valid, item_can_circulate, item_exists, \
     item_location_retriever, item_ref_builder, patron_exists
 
 
@@ -57,7 +57,7 @@ def app_config(app_config):
         checkout=dict(
             duration_default=get_default_loan_duration,
             duration_validate=is_loan_duration_valid,
-            item_available=is_item_available,
+            item_can_circulate=item_can_circulate,
         ),
         extension=dict(
             from_end_date=True,
@@ -139,12 +139,13 @@ def indexed_loans(es, test_loans):
 
 
 @pytest.fixture()
-def mock_is_item_available():
+def mock_is_item_available_for_checkout():
     """Mock item_available check."""
-    path = "invenio_circulation.transitions.base.is_item_available"
-    with mock.patch(path) as mock_is_item_available:
-        mock_is_item_available.return_value = True
-        yield mock_is_item_available
+    path = \
+        "invenio_circulation.transitions.base.is_item_available_for_checkout"
+    with mock.patch(path) as mock_is_item_available_for_checkout:
+        mock_is_item_available_for_checkout.return_value = True
+        yield mock_is_item_available_for_checkout
 
 
 @pytest.fixture()

--- a/tests/test_loan_base_constraints.py
+++ b/tests/test_loan_base_constraints.py
@@ -80,7 +80,7 @@ def test_should_fail_when_patron_is_changed(
 
 
 def test_persist_loan_parameters(
-    loan_created, db, params, mock_is_item_available
+    loan_created, db, params, mock_is_item_available_for_checkout
 ):
     """Test that input params are correctly persisted."""
     loan_pid = loan_pid_fetcher(loan_created.id, loan_created)

--- a/tests/test_loan_record.py
+++ b/tests/test_loan_record.py
@@ -29,7 +29,7 @@ def test_state_enum(app):
 
 
 def test_state_checkout_with_loan_pid(
-    loan_created, db, params, mock_is_item_available
+    loan_created, db, params, mock_is_item_available_for_checkout
 ):
     """Test that created Loan validates after a checkout action."""
     new_params = deepcopy(params)

--- a/tests/test_rest_loan_item.py
+++ b/tests/test_rest_loan_item.py
@@ -50,7 +50,8 @@ def _post(app, json_headers, params, pid_value, action):
 
 
 def test_rest_explicit_loan_valid_action(
-    app, json_headers, params, mock_is_item_available, loan_created
+    app, json_headers, params, mock_is_item_available_for_checkout,
+    loan_created
 ):
     """Test API valid action on loan."""
     loan_pid = loan_pid_fetcher(loan_created.id, loan_created)
@@ -86,7 +87,8 @@ def test_rest_automatic_loan_valid_action(
 
 
 def test_rest_loan_invalid_action(
-    app, json_headers, params, mock_is_item_available, loan_created
+    app, json_headers, params, mock_is_item_available_for_checkout,
+    loan_created
 ):
     """Test API invalid action on loan."""
     loan = current_circulation.circulation.trigger(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,8 +21,8 @@ def item_exists(item_pid):
     return True
 
 
-def is_item_available(item_pid):
-    """Return if item is available for checkout."""
+def item_can_circulate(item_pid):
+    """Return True if the item can circulate, False otherwise."""
     return True
 
 


### PR DESCRIPTION
PR introduces changed naming for the function `is_item_available` to `is_item_available_for_checkout`, as it is not explicit enough to be used without confusion with item state (in app-ils when `Item.state` is `MISSING` the name `is_item_available` creates wrong impression (that actually item is available in general)  