### PR TITLE
checkout: allow exception for active loans

### DIFF
--- a/invenio_circulation/config.py
+++ b/invenio_circulation/config.py
@@ -46,6 +46,11 @@ CIRCULATION_STATES_LOAN_ACTIVE = ['ITEM_AT_DESK',
 Items that have attached loans with these circulation statuses are
 not available to be loaned by patrons."""
 
+CIRCULATION_STATES_LOAN_ACTIVE_EXCEPT = ['ITEM_AT_DESK']
+"""Defines the list of Loan states among the CIRCULATION_STATES_LOAN_ACTIVE
+for which a checkout, for the concerned patron, is allowed."""
+
+
 CIRCULATION_STATES_LOAN_COMPLETED = ['ITEM_RETURNED']
 """Defines the list of states that a loan is considered completed.
 

--- a/invenio_circulation/transitions/base.py
+++ b/invenio_circulation/transitions/base.py
@@ -137,7 +137,8 @@ class Transition(object):
             msg = "Item '{0}' not found in catalog".format(loan['item_pid'])
             raise ItemNotAvailableError(description=msg)
 
-        if not is_item_available_for_checkout(loan['item_pid']):
+        if not is_item_available_for_checkout(
+                loan['item_pid'], patron_pid=loan['patron_pid']):
             raise ItemNotAvailableError(
                 item_pid=loan['item_pid'], transition=self.dest
             )

--- a/tests/test_loan_transitions.py
+++ b/tests/test_loan_transitions.py
@@ -447,11 +447,15 @@ def test_item_availability(indexed_loans):
     assert not is_item_available_for_checkout(item_pid="item_on_loan_2")
     assert is_item_available_for_checkout(item_pid="item_returned_3")
     assert not is_item_available_for_checkout(item_pid="item_in_transit_4")
-    assert not is_item_available_for_checkout(item_pid="item_at_desk_5")
     assert not is_item_available_for_checkout(
         item_pid="item_pending_on_loan_6")
     assert is_item_available_for_checkout(item_pid="item_returned_6")
     assert is_item_available_for_checkout(item_pid="no_loan")
+    # item is not available because it has a loan with state ITEM_AT_DESK
+    assert not is_item_available_for_checkout(item_pid="item_at_desk_5")
+    # item is available because the checked-out patron owns the active loan
+    assert is_item_available_for_checkout(
+        item_pid="item_at_desk_5", patron_pid="1")
 
 
 def test_checkout_item_unavailable_steps(loan_created,  params, users):


### PR DESCRIPTION
* Adds option to consider the at_desk item as available.
* if checked_patron is the owner of the exceptions loan.

Co-Authored-by: Olivier Dossmann <git@dossmann.net>
Co-Authored-by: Aly Badr <aly.badr@rero.ch>