### PR TITLE
loans: do not automatic item assignment on pending loans

### DIFF
--- a/invenio_circulation/api.py
+++ b/invenio_circulation/api.py
@@ -16,7 +16,7 @@ from invenio_records.api import Record
 
 from .errors import MissingRequiredParameterError, MultipleLoansOnItemError
 from .pidstore.pids import CIRCULATION_LOAN_PID_TYPE
-from .search.api import search_by_pid
+from .search.api import search_by_patron_item_or_document, search_by_pid
 from .utils import str2datetime
 
 
@@ -108,7 +108,7 @@ class Loan(Record):
         self["item_pid"] = item_pid
 
 
-def is_item_available_for_checkout(item_pid):
+def is_item_available_for_checkout(item_pid, patron_pid=None):
     """Return True if the given item is available for loan, False otherwise.
 
     :param item_pid: a dict containing `value` and `type` fields to
@@ -120,6 +120,25 @@ def is_item_available_for_checkout(item_pid):
     )
     if not cfg_item_can_circulate(item_pid):
         return False
+
+    # Some exceptions occurs with specific items and a given patron
+    # For example: ITEM_AT_DESK is available for the patron's loan
+    except_config_exists = ['ITEM_AT_DESK']
+    if patron_pid and except_config_exists:
+        item_exception_loans = 0
+        search = search_by_patron_item_or_document(
+            item_pid=item_pid,
+            patron_pid=patron_pid,
+            filter_states=except_config_exists,
+        )
+        search_result = search.execute()
+        if ES_VERSION[0] >= 7:
+            item_exception_loans = search_result.hits.total.value
+        else:
+            item_exception_loans = search_result.hits.total
+
+        if item_exception_loans == 1:
+            return True
 
     search = search_by_pid(
         item_pid=item_pid,

--- a/invenio_circulation/transitions/base.py
+++ b/invenio_circulation/transitions/base.py
@@ -142,7 +142,9 @@ class Transition(object):
             raise ItemNotAvailableError(item_pid=loan["item_pid"],
                                         transition=self.dest)
 
-        if not is_item_available_for_checkout(loan["item_pid"]):
+        if not is_item_available_for_checkout(
+                loan['item_pid'],
+                patron_pid=loan['patron_pid']):
             raise ItemNotAvailableError(
                 item_pid=loan["item_pid"], transition=self.dest
             )

--- a/invenio_circulation/transitions/transitions.py
+++ b/invenio_circulation/transitions/transitions.py
@@ -208,7 +208,7 @@ class CreatedToPending(Transition):
             permission_factory=permission_factory,
             **kwargs
         )
-        self.assign_item = kwargs.get("assign_item", True)
+        self.assign_item = kwargs.get("assign_item", False)
 
     @check_request_on_document
     def before(self, loan, **kwargs):
@@ -297,7 +297,7 @@ class ItemOnLoanToItemReturned(Transition):
             permission_factory=permission_factory,
             **kwargs
         )
-        self.assign_item = kwargs.get("assign_item", True)
+        self.assign_item = kwargs.get("assign_item", False)
 
     @ensure_same_item
     def before(self, loan, **kwargs):
@@ -335,7 +335,7 @@ class ItemInTransitHouseToItemReturned(Transition):
             permission_factory=permission_factory,
             **kwargs
         )
-        self.assign_item = kwargs.get("assign_item", True)
+        self.assign_item = kwargs.get("assign_item", False)
 
     @ensure_same_item
     def before(self, loan, **kwargs):

--- a/tests/test_loan_transitions.py
+++ b/tests/test_loan_transitions.py
@@ -517,7 +517,11 @@ def test_item_availability(indexed_loans):
     assert is_item_available_for_checkout(
         item_pid=dict(type="itemid", value="no_loan")
     )
-
+    # item is not available because it has a loan with state ITEM_AT_DESK
+    assert not is_item_available_for_checkout(item_pid="item_at_desk_5")
+    # item is available because the checked-out patron owns the active loan
+    assert is_item_available_for_checkout(
+        item_pid="item_at_desk_5", patron_pid="1")
 
 def test_checkout_item_unavailable_steps(loan_created, params, users):
     """Test checkout attempt on unavailable item."""


### PR DESCRIPTION
* Sets by default the transition assign_item to False.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>