### PR TITLE
transitions: fix ItemAtDeskToItemOnLoan transition

### DIFF
--- a/invenio_circulation/transitions/base.py
+++ b/invenio_circulation/transitions/base.py
@@ -132,8 +132,8 @@ class Transition(object):
         )
         self.validate_transition_states()
 
-    def ensure_item_is_available_for_checkout(self, loan):
-        """Validate that an item is available."""
+    def _check_item_before_availability(self, loan):
+        """Common check on item before availability check."""
         if "item_pid" not in loan:
             msg = "Item not set for loan #'{}'".format(loan["pid"])
             raise TransitionConstraintsViolationError(description=msg)
@@ -141,6 +141,10 @@ class Transition(object):
         if not current_app.config["CIRCULATION_ITEM_EXISTS"](loan["item_pid"]):
             raise ItemNotAvailableError(item_pid=loan["item_pid"],
                                         transition=self.dest)
+
+    def ensure_item_is_available_for_checkout(self, loan):
+        """Validate that an item is available."""
+        self._check_item_before_availability(loan)
 
         if not is_item_available_for_checkout(loan["item_pid"]):
             raise ItemNotAvailableError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,16 @@ def mock_is_item_available_for_checkout():
 
 
 @pytest.fixture()
+def mock_is_item_at_desk_available_for_checkout():
+    """Mock item_at_desk_available check."""
+    path = \
+        "invenio_circulation.api.is_item_at_desk_available_for_checkout"
+    with mock.patch(path) as mock_is_item_at_desk_available_for_checkout:
+        mock_is_item_at_desk_available_for_checkout.return_value = False
+        yield mock_is_item_at_desk_available_for_checkout
+
+
+@pytest.fixture()
 def mock_get_pending_loans_by_doc_pid():
     """Mock item_available check."""
     path = \

--- a/tests/test_loan_transitions.py
+++ b/tests/test_loan_transitions.py
@@ -15,7 +15,8 @@ import arrow
 import pytest
 from flask_security import login_user
 
-from invenio_circulation.api import is_item_available_for_checkout
+from invenio_circulation.api import get_loan_for_item, \
+    is_item_at_desk_available_for_checkout, is_item_available_for_checkout
 from invenio_circulation.errors import ItemDoNotMatchError, \
     LoanMaxExtensionError, NoValidTransitionAvailableError, \
     RecordCannotBeRequestedError, TransitionConstraintsViolationError
@@ -49,6 +50,7 @@ def test_override_transaction_date(
 def test_loan_checkout_checkin(
     mock_get_pending_loans_by_doc_pid,
     loan_created,
+    db,
     params,
     mock_is_item_available_for_checkout,
 ):
@@ -70,6 +72,8 @@ def test_loan_checkout_checkin(
     ):
         loan = current_circulation.circulation.trigger(loan, **dict(params))
         assert loan["state"] == "ITEM_RETURNED"
+        # Keep changes in database to make item available for checkout later
+        db.session.commit()
 
 
 def test_can_change_item_and_loc_pid_before_checkout(
@@ -506,9 +510,6 @@ def test_item_availability(indexed_loans):
         item_pid=dict(type="itemid", value="item_in_transit_4")
     )
     assert not is_item_available_for_checkout(
-        item_pid=dict(type="itemid", value="item_at_desk_5")
-    )
-    assert not is_item_available_for_checkout(
         item_pid=dict(type="itemid", value="item_pending_on_loan_6")
     )
     assert is_item_available_for_checkout(
@@ -516,6 +517,15 @@ def test_item_availability(indexed_loans):
     )
     assert is_item_available_for_checkout(
         item_pid=dict(type="itemid", value="no_loan")
+    )
+    # item is not available because it has a loan with state ITEM_AT_DESK
+    assert not is_item_available_for_checkout(
+        item_pid=dict(type="itemid", value="item_at_desk_5")
+    )
+    # item is available because the checked-out patron owns the active loan
+    assert is_item_at_desk_available_for_checkout(
+            item_pid=dict(type="itemid", value="item_at_desk_5"),
+            patron_pid="1"
     )
 
 


### PR DESCRIPTION
After our previous message here: https://github.com/inveniosoftware/invenio-circulation/pull/124#issuecomment-582902480

We start to fix the ItemAdDeskToItemOnLoan transition to follow the Loan state chart done in collaboration with the CERN and RERO here: https://github.com/rero/rero-ils/blob/master/doc/circulation_statechart/circulation_loan_statechart.pdf

So we do:

* Changes ItemAtDeskToItemOnLoan transition to inherits from Transition
* Adds additional checks on patron_pid for item availability in case of
Item_At_Desk item

These changes should not break the CERN behaviour.

Can you give me a confirmation that this is OK for you?

Co-Authored-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>