### PR TITLE
global: pass initial loan to checkout/extend duration functions

### DIFF
--- a/invenio_circulation/transitions/transitions.py
+++ b/invenio_circulation/transitions/transitions.py
@@ -23,7 +23,7 @@ from ..transitions.base import Transition
 from ..transitions.conditions import is_same_location
 
 
-def _ensure_valid_loan_duration(loan):
+def _ensure_valid_loan_duration(loan, initial_loan):
     """Validate start and end dates for a loan."""
     loan.setdefault("start_date", loan["transaction_date"])
 
@@ -31,7 +31,7 @@ def _ensure_valid_loan_duration(loan):
         get_loan_duration = current_app.config["CIRCULATION_POLICIES"][
             "checkout"
         ]["duration_default"]
-        duration = get_loan_duration(loan)
+        duration = get_loan_duration(loan, initial_loan)
         loan["end_date"] = loan["start_date"] + duration
 
     is_duration_valid = current_app.config["CIRCULATION_POLICIES"]["checkout"][
@@ -68,9 +68,12 @@ def ensure_same_item(f):
             wrong_pid_type = loan.get("item_pid") and \
                 item_pid["type"] != loan["item_pid"]["type"]
             if wrong_pid_value or wrong_pid_type:
-                msg = "Cannot change item '{0}:{1}' while performing an " \
-                      "action on this loan" \
-                    .format(item_pid["type"], item_pid["value"])
+                msg = (
+                    "Cannot change item '{0}:{1}' while performing an "
+                    "action on this loan".format(
+                        item_pid["type"], item_pid["value"]
+                    )
+                )
                 raise ItemDoNotMatchError(description=msg)
 
         return f(self, loan, **kwargs)
@@ -90,36 +93,6 @@ def _update_document_pending_request_for_item(item_pid, **kwargs):
         pending_loan.commit()
         db.session.commit()
         current_circulation.loan_indexer().index(pending_loan)
-
-
-def _ensure_valid_extension(loan):
-    """Validate end dates for a extended loan."""
-    extension_count = loan.get("extension_count", 0)
-    extension_count += 1
-
-    get_extension_max_count_func = current_app.config["CIRCULATION_POLICIES"][
-        "extension"
-    ]["max_count"]
-    extension_max_count = get_extension_max_count_func(loan)
-    if extension_count > extension_max_count:
-        raise LoanMaxExtensionError(
-            loan_pid=loan["pid"], extension_count=extension_max_count
-        )
-    loan["extension_count"] = extension_count
-
-    get_extension_duration_func = current_app.config["CIRCULATION_POLICIES"][
-        "extension"
-    ]["duration_default"]
-    duration = get_extension_duration_func(loan)
-
-    should_extend_from_end_date = current_app.config["CIRCULATION_POLICIES"][
-        "extension"
-    ]["from_end_date"]
-    if not should_extend_from_end_date:
-        # extend from the transaction_date instead
-        loan["end_date"] = loan["transaction_date"]
-
-    loan["end_date"] += duration
 
 
 def _ensure_same_location(item_pid, location_pid, destination, error_msg):
@@ -159,7 +132,7 @@ class ToItemOnLoan(Transition):
 
         _ensure_default_pickup_location(loan, kwargs)
 
-        _ensure_valid_loan_duration(loan)
+        _ensure_valid_loan_duration(loan, self.initial_loan)
 
 
 class ItemAtDeskToItemOnLoan(Transition):
@@ -173,7 +146,7 @@ class ItemAtDeskToItemOnLoan(Transition):
 
         _ensure_default_pickup_location(loan, kwargs)
 
-        _ensure_valid_loan_duration(loan)
+        _ensure_valid_loan_duration(loan, self.initial_loan)
 
     def ensure_at_desk_item_is_available_for_checkout(self, loan):
         """Validate that an item at desk is available for checkout."""
@@ -215,7 +188,8 @@ def check_request_on_document(f):
             # if no pickup location was specified in the request,
             # assign a default one
             kwargs["pickup_location_pid"] = _get_item_location(
-                kwargs["item_pid"])
+                kwargs["item_pid"]
+            )
 
         return f(self, loan, **kwargs)
     return inner
@@ -284,11 +258,43 @@ class PendingToItemInTransitPickup(Transition):
 class ItemOnLoanToItemOnLoan(Transition):
     """Extend action to perform a item loan extension."""
 
+    def update_extension_count(self, loan):
+        """Check number of extensions and update it."""
+        extension_count = loan.get("extension_count", 0)
+        extension_count += 1
+
+        get_extension_max_count_func = current_app.config[
+            "CIRCULATION_POLICIES"
+        ]["extension"]["max_count"]
+        extension_max_count = get_extension_max_count_func(loan)
+        if extension_count > extension_max_count:
+            raise LoanMaxExtensionError(
+                loan_pid=loan["pid"], extension_count=extension_max_count
+            )
+        loan["extension_count"] = extension_count
+
+    def update_loan_end_date(self, loan):
+        """Update the end date of the extended loan."""
+        get_extension_duration_func = current_app.config[
+            "CIRCULATION_POLICIES"
+        ]["extension"]["duration_default"]
+        duration = get_extension_duration_func(loan, self.initial_loan)
+
+        should_extend_from_end_date = current_app.config[
+            "CIRCULATION_POLICIES"
+        ]["extension"]["from_end_date"]
+        if not should_extend_from_end_date:
+            # extend from the transaction_date instead
+            loan["end_date"] = loan["transaction_date"]
+
+        loan["end_date"] += duration
+
     @ensure_same_item
     def before(self, loan, **kwargs):
         """Validate extension action."""
         super().before(loan, **kwargs)
-        _ensure_valid_extension(loan)
+        self.update_extension_count(loan)
+        self.update_loan_end_date(loan)
 
 
 class ItemOnLoanToItemInTransitHouse(Transition):

--- a/invenio_circulation/utils.py
+++ b/invenio_circulation/utils.py
@@ -92,8 +92,12 @@ def can_be_requested(loan):
     )
 
 
-def get_default_loan_duration(loan):
-    """Return a default loan duration in timedelta."""
+def get_default_loan_duration(loan, initial_loan):
+    """Return a default loan duration in timedelta.
+
+    :param loan: the current loan to extend, updated with transition params
+    :param initial_loan: the loan before applying transition params
+    """
     raise NotImplementedConfigurationError(
         config_variable="CIRCULATION_POLICIES.checkout.duration_default"
     )
@@ -106,8 +110,12 @@ def is_loan_duration_valid(loan):
     )
 
 
-def get_default_extension_duration(loan):
-    """Return a default extension duration in timedelta."""
+def get_default_extension_duration(loan, initial_loan):
+    """Return a default extension duration in timedelta.
+
+    :param loan: the current loan to extend, updated with transition params
+    :param initial_loan: the loan before applying transition params
+    """
     raise NotImplementedConfigurationError(
         config_variable="CIRCULATION_POLICIES.extension.duration_default"
     )

--- a/tests/test_loan_transitions.py
+++ b/tests/test_loan_transitions.py
@@ -270,7 +270,7 @@ def test_loan_extend(
             )
 
 
-def test_loan_extend_from_enddate(
+def test_loan_extend_from_transaction_date(
     loan_created, params, mock_ensure_item_is_available_for_checkout
 ):
     """Test loan extend action from transaction date."""
@@ -348,7 +348,7 @@ def test_checkout_extend_with_timedelta(
     duration = timedelta(hours=4)
     with SwappedNestedConfig(
         ["CIRCULATION_POLICIES", "checkout", "duration_default"],
-        lambda x: duration,
+        lambda _loan, _initial: duration,
     ):
         loan = current_circulation.circulation.trigger(
             loan_created, **dict(params, trigger="checkout")
@@ -364,7 +364,7 @@ def test_checkout_extend_with_timedelta(
     duration = timedelta(days=1)
     with SwappedNestedConfig(
         ["CIRCULATION_POLICIES", "extension", "duration_default"],
-        lambda x: duration,
+        lambda _loan, _initial: duration,
     ):
         # perform an extension
         loan = current_circulation.circulation.trigger(
@@ -377,7 +377,7 @@ def test_checkout_extend_with_timedelta(
     duration = timedelta(days=3, minutes=33)
     with SwappedNestedConfig(
         ["CIRCULATION_POLICIES", "extension", "duration_default"],
-        lambda x: duration,
+        lambda _loan, _initial: duration,
     ):
         # extend again
         loan = current_circulation.circulation.trigger(
@@ -396,7 +396,7 @@ def test_checkout_start_is_transaction_date(
     duration = timedelta(days=10)
     with SwappedNestedConfig(
         ["CIRCULATION_POLICIES", "checkout", "duration_default"],
-        lambda x: duration,
+        lambda _loan, _initial: duration,
     ):
         loan = current_circulation.circulation.trigger(
             loan_created, **dict(params, trigger="checkout")

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -15,8 +15,8 @@ def test_signals_loan_request(loan_created, params):
     """Test signal for loan request action."""
     recorded = []
 
-    def record_signals(_, prev_loan, loan, trigger):
-        recorded.append((prev_loan, loan, trigger))
+    def record_signals(_, initial_loan, loan, trigger):
+        recorded.append((initial_loan, loan, trigger))
 
     loan_state_changed.connect(record_signals, weak=False)
 
@@ -30,8 +30,8 @@ def test_signals_loan_request(loan_created, params):
         )
     )
     assert len(recorded) == 1
-    prev_loan, updated_loan, trigger = recorded.pop()
-    assert prev_loan["state"] == "CREATED"
+    initial_loan, updated_loan, trigger = recorded.pop()
+    assert initial_loan["state"] == "CREATED"
     assert updated_loan["state"] == "PENDING"
     assert trigger == "request"
 
@@ -40,8 +40,8 @@ def test_signals_loan_extend(loan_created, params):
     """Test signals for loan extend action."""
     recorded = []
 
-    def record_signals(_, prev_loan, loan, trigger):
-        recorded.append((prev_loan, loan, trigger))
+    def record_signals(_, initial_loan, loan, trigger):
+        recorded.append((initial_loan, loan, trigger))
 
     loan_state_changed.connect(record_signals, weak=False)
 
@@ -50,8 +50,8 @@ def test_signals_loan_extend(loan_created, params):
         loan_created, **dict(params, trigger="checkout")
     )
     assert len(recorded) == 1
-    prev_loan, updated_loan, trigger = recorded.pop()
-    assert prev_loan["state"] == "CREATED"
+    initial_loan, updated_loan, trigger = recorded.pop()
+    assert initial_loan["state"] == "CREATED"
     assert updated_loan["state"] == "ITEM_ON_LOAN"
     assert trigger == "checkout"
 
@@ -59,8 +59,8 @@ def test_signals_loan_extend(loan_created, params):
         loan, **dict(params, trigger="extend")
     )
     assert len(recorded) == 1
-    prev_loan, updated_loan, trigger = recorded.pop()
-    assert prev_loan["state"] == "ITEM_ON_LOAN"
+    initial_loan, updated_loan, trigger = recorded.pop()
+    assert initial_loan["state"] == "ITEM_ON_LOAN"
     assert updated_loan["state"] == "ITEM_ON_LOAN"
-    assert prev_loan["end_date"] != updated_loan["end_date"]
+    assert initial_loan["end_date"] != updated_loan["end_date"]
     assert trigger == "extend"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -59,12 +59,12 @@ def item_location_retriever(item_pid):
     return ""
 
 
-def get_default_loan_duration(loan):
+def get_default_loan_duration(loan, initial_loan):
     """Return a default loan duration in timedelta."""
     return timedelta(days=30)
 
 
-def get_default_extension_duration(loan):
+def get_default_extension_duration(loan, initial_loan):
     """Return a default extension duration in timedelta."""
     return timedelta(days=30)
 


### PR DESCRIPTION
- rename prev_loan to initial_loan for clarity
- pass initial_loan to the function that calculate loan duration when
  checkout or extend, so that updated and initial loan can be compared
- move the extension validation function inside its transition

**BREAKING**

- renamed the param in the `signal` from `prev_loan` to `initial_loan`
- changed the 2 `duration_default` functions in checkout and extension policies to accept a second parameter `initial_loan`