### PR TITLE
Add post_load loan record update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 Changes
 =======
 
+Version 1.0.0a27 (released 2020-09-15)
+
+- fixes the loan record update method not working properly with custom fields
+
 Version 1.0.0a26 (released 2020-07-17)
 
 - fixes `initial_loan`, a copy of loan before transition, to be a local

--- a/invenio_circulation/records/loaders/schemas/json.py
+++ b/invenio_circulation/records/loaders/schemas/json.py
@@ -15,7 +15,7 @@ from flask import current_app
 from flask_babelex import lazy_gettext as _
 from invenio_records_rest.schemas import RecordMetadataSchemaJSONV1
 from invenio_records_rest.schemas.fields import PersistentIdentifier
-from marshmallow import Schema, ValidationError, fields, validates
+from marshmallow import Schema, ValidationError, fields, post_load, validates
 
 
 class DateTimeString(fields.DateTime):
@@ -119,6 +119,16 @@ class LoanSchemaV1(RecordMetadataSchemaJSONV1):
                 _("The loan `transaction_user_pid` is not valid."),
                 field_names=["transaction_user_pid"],
             )
+
+    @post_load
+    def postload_fields(self, data, **kwargs):
+        """Post-load record fields update."""
+        record = self.context.get("record")
+        if record:
+            record.update(data)
+            return record
+        else:
+            return data
 
 
 class LoanReplaceItemSchemaV1(RecordMetadataSchemaJSONV1):

--- a/invenio_circulation/version.py
+++ b/invenio_circulation/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0a26'
+__version__ = '1.0.0a27'

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@
 pep8ignore = docs/conf.py ALL
 addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_circulation --cov-report=term-missing
 testpaths = docs tests invenio_circulation
+filterwarnings = ignore::pytest.PytestDeprecationWarning

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,7 +8,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 pydocstyle invenio_circulation tests docs && \
-isort --check-only --diff && \
+isort invenio_circulation tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test


### PR DESCRIPTION
Allows to customize the `Loan` datamodel while still benefiting from the `update` method. Previously, the custom fields would get wiped out.