### PR TITLE
loan: fix default state assignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 Changes
 =======
 
+Version 1.0.0a30 (released 2021-01-27)
+
+- fix default loan state assignment
+
 Version 1.0.0a29 (released 2020-11-26)
 
 - set transaction date default value in marshamallow loader to fix bug with start date

--- a/invenio_circulation/api.py
+++ b/invenio_circulation/api.py
@@ -37,7 +37,6 @@ class Loan(Record):
         """Constructor."""
         self.item_ref_builder = current_app.config[
             "CIRCULATION_ITEM_REF_BUILDER"]
-        self["state"] = current_app.config["CIRCULATION_LOAN_INITIAL_STATE"]
         super().__init__(data, model)
 
     @classmethod
@@ -54,6 +53,8 @@ class Loan(Record):
     def create(cls, data, id_=None, **kwargs):
         """Create Loan record."""
         data["$schema"] = current_jsonschemas.path_to_url(cls._schema)
+        data.setdefault("state",
+                        current_app.config["CIRCULATION_LOAN_INITIAL_STATE"])
         cls.build_resolver_fields(data)
 
         # resolve document if `item_pid` provided

--- a/invenio_circulation/version.py
+++ b/invenio_circulation/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_circulation.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "1.0.0a29"
+__version__ = "1.0.0a30"

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,6 @@ install_requires = [
     'invenio-pidstore>=1.1.0',
     'invenio-records-rest>=1.6.4',
     'invenio-jsonschemas>=1.0.1',
-    # temporarily, until fixed compatibility
-    'invenio-records>=1.3.0,<1.4.0',
 ]
 
 packages = find_packages()

--- a/tests/test_rest_loan_replace_item.py
+++ b/tests/test_rest_loan_replace_item.py
@@ -41,10 +41,12 @@ def test_loan_replace_item(app, json_headers, indexed_loans):
 
 def test_loan_replace_item_inactive_state(app, json_headers, indexed_loans):
     """Test item replacement on a Loan that is not active."""
+    loan = None
     for _pid, _loan in indexed_loans:
         if _loan["state"] == "ITEM_RETURNED":
             loan = _loan
             break
+    assert loan
     payload = dict(item_pid=dict(type="itemid", value="new_item_pid"))
     res, data = _post(app, json_headers, loan, payload)
     assert data["status"] == 400


### PR DESCRIPTION
* invenio 3.4 compatibility fix for
  default state assignment in Loan
  
  dear reviewers:
- after the update to invenio 3.4 the assignment of the initial state done in this way was not compatible with changes in invenio-records. The fields should not be assigned to the `self`, in order to align with the concept of encoding/decoding the json model field to/from python dict (see https://github.com/inveniosoftware/invenio-records/blob/v1.4.0/invenio_records/api.py#L173)