### PR TITLE
Errors: Werkzeug 2 compatibility fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@
 Changes
 =======
 
+Version 1.0.0a35 (released 2021-11-26)
+
+- Made compatibility changes for werkzeug 2
+- Bumped Sphinx
+
 Version 1.0.0a34 (released 2021-10-26)
 
 - make "same location" check overridable

--- a/invenio_circulation/errors.py
+++ b/invenio_circulation/errors.py
@@ -24,7 +24,7 @@ class CirculationException(RESTException):
         """The status name."""
         return type(self).__name__
 
-    def get_body(self, environ=None):
+    def get_body(self, environ=None, scope=None):
         """Get the request body."""
         body = dict(
             status=self.code,

--- a/invenio_circulation/version.py
+++ b/invenio_circulation/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_circulation.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "1.0.0a34"
+__version__ = "1.0.0a35"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
         'elasticsearch>=7.0.0,<7.14',
     ],
     'docs': [
-        'Sphinx>=3.3.1,<3.4',
+        'Sphinx>=4.2.0',
     ],
     'mysql': [
         'invenio-db[mysql,versioning]>={}'.format(invenio_db_version)


### PR DESCRIPTION
Added the "scope" positional argument needed in newer releases of werkzeug