### PR TITLE
format code with black, allow for extensions to be added to loans index and update loan transition signal

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+44fe1c1effed690c9322d0fb5dc60f05c14c7eac

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2025 CERN.
 #
 # CDS-ILS is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,64 +14,20 @@ on:
     branches: master
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: "0 3 * * 6"
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason'
+        description: "Reason"
         required: false
-        default: 'Manual trigger'
+        default: "Manual trigger"
+
 
 jobs:
-  Tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-          python-version: [3.9]
-          requirements-level: [pypi]
-          db-service: [postgresql13, postgresql14]
-          search-service: [elasticsearch7, opensearch2]
-          include:
-          - search-service: opensearch2
-            SEARCH_EXTRAS: "opensearch2"
-
-          - search-service: elasticsearch7
-            SEARCH_EXTRAS: "elasticsearch7"
-
-    env:
-      DB: ${{ matrix.db-service }}
-      SEARCH: ${{ matrix.search-service }}
-      EXTRAS: tests,${{ matrix.SEARCH_EXTRAS }},postgresql
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Generate dependencies
-        run: |
-          pip install wheel requirements-builder
-          requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-          cat .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
-
-      - name: Install dependencies
-        run: |
-          pip install -r .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-          pip install .[$EXTRAS]
-          pip freeze
-          docker --version
-          docker-compose --version
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+  Python:
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
+    with:
+      extras: 'postgresql,tests'
+      python-version: '["3.9"]'
+      db-service: '["postgresql13", "postgresql14"]'
+      search-service: '["elasticsearch7", "opensearch2"]'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,11 @@ on:
         required: false
         default: "Manual trigger"
 
-
 jobs:
   Python:
     uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
     with:
       extras: 'postgresql,tests'
       python-version: '["3.9"]'
-      db-service: '["postgresql13", "postgresql14"]'
+      db-service: '["postgresql14"]'
       search-service: '["elasticsearch7", "opensearch2"]'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,20 @@
 ..
-    Copyright (C) 2018-2020 CERN.
+    Copyright (C) 2018-2025 CERN.
     Copyright (C) 2018-2020 RERO.
     Invenio-Circulation is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
 
 Changes
 =======
+
+Version v4.0.0 (released 2025-11-24)
+
+- tests: drop support for testing postgresql13
+- tests: make use of inveniosoftware standard ci workflow
+- index: add `extra_data` property to loan mapping
+- (breaking) global: make first parameter of `loan_state_changed` signal the `current_object`
+- chore: add commit that formats project with black to `git-blame-ignore-refs`
+- chore: format code with black
 
 Version v3.0.0a1 (released 2023-12-05)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,6 +23,7 @@ include *.txt
 include LICENSE
 include babel.ini
 include pytest.ini
+include .git-blame-ignore-revs
 prune docs/_build
 recursive-include invenio_circulation *.po *.pot *.mo *.html
 recursive-include docs *.png

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,40 +17,40 @@ from invenio_circulation import __version__
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Do not warn on external images.
-suppress_warnings = ['image.nonlocal_uri']
+suppress_warnings = ["image.nonlocal_uri"]
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.coverage',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'Invenio-Circulation'
-copyright = u'2018, CERN'
-author = u'CERN'
+project = "Invenio-Circulation"
+copyright = "2018, CERN"
+author = "CERN"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -66,13 +66,13 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -80,46 +80,46 @@ exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 html_theme_options = {
-    'description': 'Invenio module for the circulation of bibliographic items.',
-    'github_user': 'inveniosoftware',
-    'github_repo': 'invenio-circulation',
-    'github_button': False,
-    'github_banner': True,
-    'show_powered_by': False,
-    'extra_nav_links': {
-        'invenio-circulation@GitHub': 'https://github.com/inveniosoftware/invenio-circulation',
-        'invenio-circulation@PyPI': 'https://pypi.python.org/pypi/invenio-circulation/',
-    }
+    "description": "Invenio module for the circulation of bibliographic items.",
+    "github_user": "inveniosoftware",
+    "github_repo": "invenio-circulation",
+    "github_button": False,
+    "github_banner": True,
+    "show_powered_by": False,
+    "extra_nav_links": {
+        "invenio-circulation@GitHub": "https://github.com/inveniosoftware/invenio-circulation",
+        "invenio-circulation@PyPI": "https://pypi.python.org/pypi/invenio-circulation/",
+    },
 }
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -128,146 +128,148 @@ html_theme_options = {
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',
-        'searchbox.html',
-        'donate.html',
+    "**": [
+        "about.html",
+        "navigation.html",
+        "relations.html",
+        "searchbox.html",
+        "donate.html",
     ]
 }
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'invenio-circulation_namedoc'
+htmlhelp_basename = "invenio-circulation_namedoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'invenio-circulation.tex', u'invenio-circulation Documentation',
-     u'CERN', 'manual'),
+    (
+        master_doc,
+        "invenio-circulation.tex",
+        "invenio-circulation Documentation",
+        "CERN",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
@@ -275,12 +277,17 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'invenio-circulation', u'invenio-circulation Documentation',
-     [author], 1)
+    (
+        master_doc,
+        "invenio-circulation",
+        "invenio-circulation Documentation",
+        [author],
+        1,
+    )
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -289,30 +296,36 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'invenio-circulation', u'Invenio-Circulation Documentation',
-     author, 'invenio-circulation', 'Invenio module for the circulation of bibliographic items.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "invenio-circulation",
+        "Invenio-Circulation Documentation",
+        author,
+        "invenio-circulation",
+        "Invenio module for the circulation of bibliographic items.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
+    "python": ("https://docs.python.org/", None),
     # TODO: Configure external documentation references, eg:
     # 'Flask-Admin': ('https://flask-admin.readthedocs.io/en/latest/', None),
 }
 
 # Autodoc configuraton.
-autoclass_content = 'both'
+autoclass_content = "both"

--- a/invenio_circulation/__init__.py
+++ b/invenio_circulation/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CERN.
+# Copyright (C) 2018-2025 CERN.
 # Copyright (C) 2018 RERO.
 #
 # Invenio-Circulation is free software; you can redistribute it and/or modify
@@ -10,6 +10,6 @@
 
 from .ext import InvenioCirculation
 
-__version__ = "3.0.0a1"
+__version__ = "4.0.0"
 
 __all__ = ("__version__", "InvenioCirculation")

--- a/invenio_circulation/__init__.py
+++ b/invenio_circulation/__init__.py
@@ -12,4 +12,4 @@ from .ext import InvenioCirculation
 
 __version__ = "3.0.0a1"
 
-__all__ = ('__version__', 'InvenioCirculation')
+__all__ = ("__version__", "InvenioCirculation")

--- a/invenio_circulation/api.py
+++ b/invenio_circulation/api.py
@@ -34,8 +34,7 @@ class Loan(Record):
 
     def __init__(self, data, model=None):
         """Constructor."""
-        self.item_ref_builder = current_app.config[
-            "CIRCULATION_ITEM_REF_BUILDER"]
+        self.item_ref_builder = current_app.config["CIRCULATION_ITEM_REF_BUILDER"]
         super().__init__(data, model)
 
     @classmethod
@@ -52,14 +51,12 @@ class Loan(Record):
     def create(cls, data, id_=None, **kwargs):
         """Create Loan record."""
         data["$schema"] = current_jsonschemas.path_to_url(cls._schema)
-        data.setdefault("state",
-                        current_app.config["CIRCULATION_LOAN_INITIAL_STATE"])
+        data.setdefault("state", current_app.config["CIRCULATION_LOAN_INITIAL_STATE"])
         cls.build_resolver_fields(data)
 
         # resolve document if `item_pid` provided
         if data.get("item_pid"):
-            data["document_pid"] = get_document_pid_by_item_pid(
-                data["item_pid"])
+            data["document_pid"] = get_document_pid_by_item_pid(data["item_pid"])
 
         return super().create(data, id_=id_, **kwargs)
 
@@ -102,9 +99,7 @@ class Loan(Record):
         """
         if not item_pid:
             msg = "Missing required arg 'item_pid' when updating loan '{}'"
-            raise MissingRequiredParameterError(
-                description=msg.format(self["pid"])
-            )
+            raise MissingRequiredParameterError(description=msg.format(self["pid"]))
         self["item_pid"] = item_pid
 
 
@@ -165,7 +160,7 @@ def get_pending_loans_by_item_pid(item_pid):
     """
     search = search_by_pid(
         item_pid=item_pid,
-        filter_states=current_app.config["CIRCULATION_STATES_LOAN_REQUEST"]
+        filter_states=current_app.config["CIRCULATION_STATES_LOAN_REQUEST"],
     )
     for result in search.scan():
         yield Loan.get_record_by_pid(result["pid"])
@@ -175,9 +170,7 @@ def get_pending_loans_by_doc_pid(document_pid):
     """Return any pending loans for the given document."""
     search = search_by_pid(
         document_pid=document_pid,
-        filter_states=current_app.config.get(
-            "CIRCULATION_STATES_LOAN_REQUEST"
-        ),
+        filter_states=current_app.config.get("CIRCULATION_STATES_LOAN_REQUEST"),
     )
     for result in search.scan():
         yield Loan.get_record_by_pid(result["pid"])
@@ -193,16 +186,12 @@ def get_available_item_by_doc_pid(document_pid):
 
 def get_items_by_doc_pid(document_pid):
     """Return a list of item PIDs for this document."""
-    return current_app.config["CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT"](
-        document_pid
-    )
+    return current_app.config["CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT"](document_pid)
 
 
 def get_document_pid_by_item_pid(item_pid):
     """Return the document pid of this item_pid."""
-    return current_app.config["CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM"](
-        item_pid
-    )
+    return current_app.config["CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM"](item_pid)
 
 
 def get_loan_for_item(item_pid):

--- a/invenio_circulation/config.py
+++ b/invenio_circulation/config.py
@@ -58,14 +58,15 @@ CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT = None
 CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM = None
 """Function that returns the Document PID of a given Item PID."""
 
-CIRCULATION_STATES_LOAN_REQUEST = ['PENDING']
+CIRCULATION_STATES_LOAN_REQUEST = ["PENDING"]
 """Defines the list of states for which the loan is considered requested."""
 
-CIRCULATION_STATES_LOAN_ACTIVE = ['ITEM_AT_DESK',
-                                  'ITEM_ON_LOAN',
-                                  'ITEM_IN_TRANSIT_FOR_PICKUP',
-                                  'ITEM_IN_TRANSIT_TO_HOUSE',
-                                  ]
+CIRCULATION_STATES_LOAN_ACTIVE = [
+    "ITEM_AT_DESK",
+    "ITEM_ON_LOAN",
+    "ITEM_IN_TRANSIT_FOR_PICKUP",
+    "ITEM_IN_TRANSIT_TO_HOUSE",
+]
 """Defines the list of Loan states for which a Loan is considered as active.
 
 Items that have attached loans with these circulation statuses are
@@ -119,9 +120,7 @@ CIRCULATION_LOAN_TRANSITIONS = {
         dict(dest="CANCELLED", trigger="cancel", transition=ToCancelled),
     ],
     "ITEM_IN_TRANSIT_TO_HOUSE": [
-        dict(
-            dest="ITEM_RETURNED", transition=ItemInTransitHouseToItemReturned
-        ),
+        dict(dest="ITEM_RETURNED", transition=ItemInTransitHouseToItemReturned),
         dict(dest="CANCELLED", trigger="cancel", transition=ToCancelled),
     ],
     "ITEM_RETURNED": [],
@@ -150,8 +149,7 @@ CIRCULATION_TRANSACTION_LOCATION_VALIDATOR = transaction_location_validator
 CIRCULATION_TRANSACTION_USER_VALIDATOR = transaction_user_validator
 """Function that validates the User PID of the given transaction."""
 
-CIRCULATION_LOAN_LOCATIONS_VALIDATION = \
-    validate_item_pickup_transaction_locations
+CIRCULATION_LOAN_LOCATIONS_VALIDATION = validate_item_pickup_transaction_locations
 """Function that verifies pending loan item, pickup and transaction locs."""
 
 CIRCULATION_SAME_LOCATION_VALIDATOR = same_location_validator
@@ -208,24 +206,16 @@ CIRCULATION_REST_ENDPOINTS = dict(
         search_class=LoansSearch,
         record_class=Loan,
         record_loaders={
-            "application/json": (
-                "invenio_circulation.records.loaders:loan_loader"
-            )
+            "application/json": ("invenio_circulation.records.loaders:loan_loader")
         },
         record_serializers={
-            "application/json": (
-                "invenio_records_rest.serializers:json_v1_response"
-            )
+            "application/json": ("invenio_records_rest.serializers:json_v1_response")
         },
         search_serializers={
-            "application/json": (
-                "invenio_records_rest.serializers:json_v1_search"
-            )
+            "application/json": ("invenio_records_rest.serializers:json_v1_search")
         },
         list_route="/circulation/loans/",
-        item_route="/circulation/loans/<{0}:pid_value>".format(
-            _LOANID_CONVERTER
-        ),
+        item_route="/circulation/loans/<{0}:pid_value>".format(_LOANID_CONVERTER),
         default_media_type="application/json",
         max_result_window=10000,
         error_handlers=dict(),

--- a/invenio_circulation/errors.py
+++ b/invenio_circulation/errors.py
@@ -51,9 +51,8 @@ class InvalidPermissionError(CirculationException):
 
     def __init__(self, permission=None, **kwargs):
         """Initialize exception."""
-        self.description = (
-            "This action is not permitted "
-            "for your role '{}'".format(permission)
+        self.description = "This action is not permitted " "for your role '{}'".format(
+            permission
         )
         super().__init__(**kwargs)
 
@@ -103,9 +102,12 @@ class ItemNotAvailableError(CirculationException):
             uniquely identify the item.
         :param transition: the transition that failed.
         """
-        self.description = "The item requested with PID '{0}:{1}' is not " \
-                           "available. Transition to '{2}' has failed." \
-            .format(item_pid["type"], item_pid["value"], transition)
+        self.description = (
+            "The item requested with PID '{0}:{1}' is not "
+            "available. Transition to '{2}' has failed.".format(
+                item_pid["type"], item_pid["value"], transition
+            )
+        )
         super().__init__(**kwargs)
 
 
@@ -138,8 +140,9 @@ class MultipleLoansOnItemError(CirculationException):
         :param item_pid: a dict containing `value` and `type` fields to
             uniquely identify the item.
         """
-        self.description = "Multiple active loans on item with PID '{0}:{1}'" \
-            .format(item_pid["type"], item_pid["value"])
+        self.description = "Multiple active loans on item with PID '{0}:{1}'".format(
+            item_pid["type"], item_pid["value"]
+        )
         super().__init__(**kwargs)
 
 

--- a/invenio_circulation/ext.py
+++ b/invenio_circulation/ext.py
@@ -48,17 +48,13 @@ class InvenioCirculation(object):
 
         # update RECORDS_REST_ENDPOINTS if not already set
         app.config.setdefault("RECORDS_REST_ENDPOINTS", {})
-        app.config["RECORDS_REST_ENDPOINTS"].setdefault(
-            CIRCULATION_LOAN_PID_TYPE, obj
-        )
+        app.config["RECORDS_REST_ENDPOINTS"].setdefault(CIRCULATION_LOAN_PID_TYPE, obj)
 
         app.extensions["invenio-circulation"] = self
 
     def init_config(self, app):
         """Initialize configuration."""
-        app.config.setdefault(
-            "CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT", lambda x: []
-        )
+        app.config.setdefault("CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT", lambda x: [])
         app.config.setdefault(
             "CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM", lambda x: None
         )
@@ -132,6 +128,4 @@ class _Circulation(object):
             except TransitionConditionsFailedError:
                 pass
 
-        raise NoValidTransitionAvailableError(
-            loan_pid=loan["pid"], state=current_state
-        )
+        raise NoValidTransitionAvailableError(loan_pid=loan["pid"], state=current_state)

--- a/invenio_circulation/links.py
+++ b/invenio_circulation/links.py
@@ -19,11 +19,9 @@ def loan_links_factory(pid, record=None):
     links = {}
     record = record or Loan.get_record_by_pid(pid.pid_value)
     actions = {}
-    transitions_config = current_app.config.get(
-        'CIRCULATION_LOAN_TRANSITIONS', {}
-    )
-    for transition in transitions_config.get(record['state']):
-        action = transition.get('trigger', 'next')
+    transitions_config = current_app.config.get("CIRCULATION_LOAN_TRANSITIONS", {})
+    for transition in transitions_config.get(record["state"]):
+        action = transition.get("trigger", "next")
         actions[action] = build_url_action_for_pid(pid, action)
-    links.setdefault('actions', actions)
+    links.setdefault("actions", actions)
     return links

--- a/invenio_circulation/mappings/os-v2/loans/loan-v1.0.0.json
+++ b/invenio_circulation/mappings/os-v2/loans/loan-v1.0.0.json
@@ -78,6 +78,11 @@
       },
       "trigger": {
         "type": "keyword"
+      },
+      "extra_data": {
+        "type": "object",
+        "dynamic": true,
+        "enabled": true
       }
     }
   }

--- a/invenio_circulation/permissions.py
+++ b/invenio_circulation/permissions.py
@@ -15,7 +15,7 @@ from invenio_access import action_factory
 from invenio_access.permissions import Permission
 from invenio_records_rest.utils import allow_all
 
-loan_read_access = action_factory('loan-read-access')
+loan_read_access = action_factory("loan-read-access")
 
 
 def check_permission(permission):
@@ -38,9 +38,9 @@ def has_read_loan_permission(*args, **kwargs):
 
 def views_permissions_factory(action):
     """Circulation views permissions factory."""
-    if action == 'loan-read-access':
+    if action == "loan-read-access":
         return allow_all()
-    elif action == 'loan-actions':
+    elif action == "loan-actions":
         return allow_all()
 
 
@@ -49,13 +49,15 @@ def need_permissions(action):
 
     :param action: The action to evaluate permissions.
     """
+
     def decorator_builder(f):
         @wraps(f)
         def decorate(*args, **kwargs):
             check_permission(
-                current_app
-                .config['CIRCULATION_VIEWS_PERMISSIONS_FACTORY'](action)
+                current_app.config["CIRCULATION_VIEWS_PERMISSIONS_FACTORY"](action)
             )
             return f(*args, **kwargs)
+
         return decorate
+
     return decorator_builder

--- a/invenio_circulation/pidstore/fetchers.py
+++ b/invenio_circulation/pidstore/fetchers.py
@@ -17,7 +17,5 @@ from .pids import CIRCULATION_LOAN_PID_TYPE
 def loan_pid_fetcher(record_uuid, data):
     """Fetch PID from loan record."""
     return FetchedPID(
-        provider=None,
-        pid_type=CIRCULATION_LOAN_PID_TYPE,
-        pid_value=str(data["pid"])
+        provider=None, pid_type=CIRCULATION_LOAN_PID_TYPE, pid_value=str(data["pid"])
     )

--- a/invenio_circulation/pidstore/minters.py
+++ b/invenio_circulation/pidstore/minters.py
@@ -16,7 +16,7 @@ def loan_pid_minter(record_uuid, data):
     """Mint loan identifiers."""
     assert "pid" not in data
     provider = CirculationLoanIdProvider.create(
-        object_type='rec',
+        object_type="rec",
         object_uuid=record_uuid,
     )
     data["pid"] = provider.pid.pid_value

--- a/invenio_circulation/pidstore/pids.py
+++ b/invenio_circulation/pidstore/pids.py
@@ -8,13 +8,13 @@
 
 """Circulation PIDs."""
 
-CIRCULATION_LOAN_PID_TYPE = 'loanid'
+CIRCULATION_LOAN_PID_TYPE = "loanid"
 """Persistent Identifier for Loans."""
 
-CIRCULATION_LOAN_MINTER = 'loanid'
+CIRCULATION_LOAN_MINTER = "loanid"
 """Minter PID for Loans."""
 
-CIRCULATION_LOAN_FETCHER = 'loanid'
+CIRCULATION_LOAN_FETCHER = "loanid"
 """Fetcher PID for Loans."""
 
 _LOANID_CONVERTER = 'pid(loanid,record_class="invenio_circulation.api:Loan")'

--- a/invenio_circulation/proxies.py
+++ b/invenio_circulation/proxies.py
@@ -11,7 +11,5 @@
 from flask import current_app
 from werkzeug.local import LocalProxy
 
-current_circulation = LocalProxy(
-    lambda: current_app.extensions['invenio-circulation']
-)
+current_circulation = LocalProxy(lambda: current_app.extensions["invenio-circulation"])
 """Helper proxy to circulation state object."""

--- a/invenio_circulation/records/jsonresolver/document.py
+++ b/invenio_circulation/records/jsonresolver/document.py
@@ -16,9 +16,12 @@ from werkzeug.routing import Rule
 def jsonresolver_loader(url_map):
     """Resolve the patron reference."""
     from flask import current_app as app
-    resolving_path = app.config.get(
-        "CIRCULATION_DOCUMENT_RESOLVING_PATH") or "/"
-    url_map.add(Rule(
-        resolving_path,
-        endpoint=app.config.get('CIRCULATION_DOCUMENT_RESOLVER_ENDPOINT'),
-        host=app.config.get('JSONSCHEMAS_HOST')))
+
+    resolving_path = app.config.get("CIRCULATION_DOCUMENT_RESOLVING_PATH") or "/"
+    url_map.add(
+        Rule(
+            resolving_path,
+            endpoint=app.config.get("CIRCULATION_DOCUMENT_RESOLVER_ENDPOINT"),
+            host=app.config.get("JSONSCHEMAS_HOST"),
+        )
+    )

--- a/invenio_circulation/records/jsonresolver/item.py
+++ b/invenio_circulation/records/jsonresolver/item.py
@@ -16,9 +16,12 @@ from werkzeug.routing import Rule
 def jsonresolver_loader(url_map):
     """Resolve the item reference."""
     from flask import current_app
-    resolving_path = current_app.config.get(
-        "CIRCULATION_ITEM_RESOLVING_PATH") or "/"
-    url_map.add(Rule(
-        resolving_path,
-        endpoint=current_app.config.get('CIRCULATION_ITEM_RESOLVER_ENDPOINT'),
-        host=current_app.config.get('JSONSCHEMAS_HOST')))
+
+    resolving_path = current_app.config.get("CIRCULATION_ITEM_RESOLVING_PATH") or "/"
+    url_map.add(
+        Rule(
+            resolving_path,
+            endpoint=current_app.config.get("CIRCULATION_ITEM_RESOLVER_ENDPOINT"),
+            host=current_app.config.get("JSONSCHEMAS_HOST"),
+        )
+    )

--- a/invenio_circulation/records/jsonresolver/patron.py
+++ b/invenio_circulation/records/jsonresolver/patron.py
@@ -16,8 +16,12 @@ from werkzeug.routing import Rule
 def jsonresolver_loader(url_map):
     """Resolve the patron reference."""
     from flask import current_app as app
+
     resolving_path = app.config.get("CIRCULATION_PATRON_RESOLVING_PATH") or "/"
-    url_map.add(Rule(
-        resolving_path,
-        endpoint=app.config.get('CIRCULATION_PATRON_RESOLVER_ENDPOINT'),
-        host=app.config.get('JSONSCHEMAS_HOST')))
+    url_map.add(
+        Rule(
+            resolving_path,
+            endpoint=app.config.get("CIRCULATION_PATRON_RESOLVER_ENDPOINT"),
+            host=app.config.get("JSONSCHEMAS_HOST"),
+        )
+    )

--- a/invenio_circulation/records/loaders/schemas/json.py
+++ b/invenio_circulation/records/loaders/schemas/json.py
@@ -34,10 +34,7 @@ class DateTimeString(fields.DateTime):
     def validate_timezone(self, value):
         """Validate that the passed timezone, if any, is UTC."""
         # strong validation of input datetime to require UTC timezone
-        if (
-            arrow.get(value).isoformat()
-            != arrow.get(value).to("utc").isoformat()
-        ):
+        if arrow.get(value).isoformat() != arrow.get(value).to("utc").isoformat():
             raise ValidationError(_("Not a valid ISO-8601 UTC datetime."))
 
     def deserialize(self, value, attr=None, data=None, **kwargs):

--- a/invenio_circulation/search/api.py
+++ b/invenio_circulation/search/api.py
@@ -44,14 +44,13 @@ def search_by_pid(
     if document_pid:
         search = search.filter("term", document_pid=document_pid)
     elif item_pid:
-        search = search \
-            .filter("term", item_pid__value=item_pid["value"]) \
-            .filter("term", item_pid__type=item_pid["type"])
+        search = search.filter("term", item_pid__value=item_pid["value"]).filter(
+            "term", item_pid__type=item_pid["type"]
+        )
     else:
         raise MissingRequiredParameterError(
             description=(
-                "One of the parameters 'item_pid' "
-                "or 'document_pid' is required."
+                "One of the parameters 'item_pid' " "or 'document_pid' is required."
             )
         )
 
@@ -74,9 +73,9 @@ def search_by_patron_item_or_document(
     search = search_cls().filter("term", patron_pid=patron_pid)
 
     if item_pid:
-        search = search \
-            .filter("term", item_pid__value=item_pid["value"]) \
-            .filter("term", item_pid__type=item_pid["type"])
+        search = search.filter("term", item_pid__value=item_pid["value"]).filter(
+            "term", item_pid__type=item_pid["type"]
+        )
     if document_pid:
         search = search.filter("term", document_pid=document_pid)
 

--- a/invenio_circulation/signals.py
+++ b/invenio_circulation/signals.py
@@ -12,14 +12,14 @@ from blinker import Namespace
 
 _signals = Namespace()
 
-loan_state_changed = _signals.signal('loan-state-changed')
+loan_state_changed = _signals.signal("loan-state-changed")
 """Loan state changed signal.
 
 Broadcasted when a loan action is triggered, sending the old and the updated
 loan object.
 """
 
-loan_replace_item = _signals.signal('loan-replace-item')
+loan_replace_item = _signals.signal("loan-replace-item")
 """Loan item changed signal.
 
 Broadcasted when the item in a Loan is replaced, sending the old and the new

--- a/invenio_circulation/transitions/base.py
+++ b/invenio_circulation/transitions/base.py
@@ -209,7 +209,8 @@ class Transition(object):
         current_circulation.loan_indexer().index(loan)
 
         loan_state_changed.send(
-            self,
+            current_app._get_current_object(),
+            transition=self,
             initial_loan=initial_loan,
             loan=loan,
             trigger=self.trigger,

--- a/invenio_circulation/utils.py
+++ b/invenio_circulation/utils.py
@@ -16,9 +16,7 @@ from .errors import NotImplementedConfigurationError
 
 def patron_exists(patron_pid):
     """Return True if patron exists, False otherwise."""
-    raise NotImplementedConfigurationError(
-        config_variable="CIRCULATION_PATRON_EXISTS"
-    )
+    raise NotImplementedConfigurationError(config_variable="CIRCULATION_PATRON_EXISTS")
 
 
 def item_exists(item_pid):
@@ -27,9 +25,7 @@ def item_exists(item_pid):
     :param item_pid: a dict containing `value` and `type` fields to
         uniquely identify the item.
     """
-    raise NotImplementedConfigurationError(
-        config_variable="CIRCULATION_ITEM_EXISTS"
-    )
+    raise NotImplementedConfigurationError(config_variable="CIRCULATION_ITEM_EXISTS")
 
 
 def document_exists(document_pid):
@@ -152,7 +148,7 @@ def transaction_user_validator(transaction_user_pid):
 
 def str2datetime(str_date):
     """Parse string date with timezone and return a datetime object."""
-    return arrow.get(str_date).to('utc')
+    return arrow.get(str_date).to("utc")
 
 
 def validate_item_pickup_transaction_locations(loan, destination, **kwargs):
@@ -180,6 +176,7 @@ def same_location_validator(item_pid, location_pid):
     :param location_pid: a location pid.
     :return: False if validation is not possible, otherwise True
     """
-    item_location_pid = \
-        current_app.config["CIRCULATION_ITEM_LOCATION_RETRIEVER"](item_pid)
+    item_location_pid = current_app.config["CIRCULATION_ITEM_LOCATION_RETRIEVER"](
+        item_pid
+    )
     return location_pid == item_location_pid

--- a/invenio_circulation/views.py
+++ b/invenio_circulation/views.py
@@ -55,8 +55,7 @@ def _get_loan_endpoint_options(app):
     default_media_type = options.get("default_media_type", "")
     rec_serializers = options.get("record_serializers", {})
     serializers = {
-        mime: obj_or_import_string(func)
-        for mime, func in rec_serializers.items()
+        mime: obj_or_import_string(func) for mime, func in rec_serializers.items()
     }
     return (
         options,
@@ -70,15 +69,12 @@ def _get_loan_endpoint_options(app):
 
 def create_loan_actions_blueprint(app):
     """Create a blueprint for Loan actions."""
-    blueprint = Blueprint(
-        "invenio_circulation_loan_actions", __name__, url_prefix=""
-    )
+    blueprint = Blueprint("invenio_circulation_loan_actions", __name__, url_prefix="")
 
     all_options, view_options = _get_loan_endpoint_options(app)
     view_options["ctx"]["loader"] = loan_loader
     loan_actions = LoanActionResource.as_view(
-        LoanActionResource.view_name.format(CIRCULATION_LOAN_PID_TYPE),
-        **view_options
+        LoanActionResource.view_name.format(CIRCULATION_LOAN_PID_TYPE), **view_options
     )
 
     distinct_actions = extract_transitions_from_app(app)
@@ -114,9 +110,7 @@ class LoanActionResource(ContentNegotiatedMethodView):
             pid,
             record,
             202,
-            links_factory=current_app.config.get(
-                "CIRCULATION_LOAN_LINKS_FACTORY"
-            ),
+            links_factory=current_app.config.get("CIRCULATION_LOAN_LINKS_FACTORY"),
         )
 
 
@@ -133,9 +127,7 @@ def create_loan_replace_item_blueprint(app):
         **view_options
     )
 
-    url = "circulation/loans/<{0}:pid_value>/replace-item".format(
-        _LOANID_CONVERTER
-    )
+    url = "circulation/loans/<{0}:pid_value>/replace-item".format(_LOANID_CONVERTER)
     blueprint.add_url_rule(url, view_func=replace_item_view, methods=["POST"])
     return blueprint
 
@@ -193,14 +185,13 @@ class LoanReplaceItemResource(ContentNegotiatedMethodView):
         current_circulation.loan_indexer().index(record)
 
         if old_item_pid:
-            loan_replace_item.send(self, old_item_pid=old_item_pid,
-                                   new_item_pid=new_item_pid)
+            loan_replace_item.send(
+                self, old_item_pid=old_item_pid, new_item_pid=new_item_pid
+            )
 
         return self.make_response(
             pid,
             record,
             202,
-            links_factory=current_app.config.get(
-                "CIRCULATION_LOAN_LINKS_FACTORY"
-            ),
+            links_factory=current_app.config.get("CIRCULATION_LOAN_LINKS_FACTORY"),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,8 +59,9 @@ def app_config(app_config):
     """Flask application fixture."""
     app_config["JSONSCHEMAS_ENDPOINT"] = "/schema"
     app_config["JSONSCHEMAS_HOST"] = "localhost:5000"
-    app_config["SQLALCHEMY_DATABASE_URI"] = \
+    app_config["SQLALCHEMY_DATABASE_URI"] = (
         "postgresql+psycopg2://invenio:invenio@localhost/invenio"
+    )
     app_config["RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY"] = allow_all
     app_config["CIRCULATION_ITEM_EXISTS"] = item_exists
     app_config["CIRCULATION_DOCUMENT_EXISTS"] = document_exists
@@ -69,16 +70,15 @@ def app_config(app_config):
     app_config["CIRCULATION_PATRON_REF_BUILDER"] = patron_ref_builder
     app_config["CIRCULATION_DOCUMENT_REF_BUILDER"] = document_ref_builder
     app_config["CIRCULATION_ITEM_LOCATION_RETRIEVER"] = item_location_retriever
-    app_config["CIRCULATION_TRANSACTION_LOCATION_VALIDATOR"] = \
+    app_config["CIRCULATION_TRANSACTION_LOCATION_VALIDATOR"] = (
         transaction_location_validator
-    app_config["CIRCULATION_TRANSACTION_USER_VALIDATOR"] = \
-        transaction_user_validator
-    app_config["CIRCULATION_LOAN_LOCATIONS_VALIDATION"] = \
+    )
+    app_config["CIRCULATION_TRANSACTION_USER_VALIDATOR"] = transaction_user_validator
+    app_config["CIRCULATION_LOAN_LOCATIONS_VALIDATION"] = (
         validate_item_pickup_transaction_locations
-    app_config["CIRCULATION_SAME_LOCATION_VALIDATOR"] = \
-        same_location_validator
-    app_config["CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM"] = \
-        lambda x: "document_pid"
+    )
+    app_config["CIRCULATION_SAME_LOCATION_VALIDATOR"] = same_location_validator
+    app_config["CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM"] = lambda x: "document_pid"
     app_config["CIRCULATION_POLICIES"] = dict(
         checkout=dict(
             duration_default=get_default_loan_duration,
@@ -90,9 +90,7 @@ def app_config(app_config):
             duration_default=get_default_extension_duration,
             max_count=get_default_extension_max_count,
         ),
-        request=dict(
-            can_be_requested=can_be_requested
-        )
+        request=dict(can_be_requested=can_be_requested),
     )
     return app_config
 
@@ -166,8 +164,7 @@ def indexed_loans(es, test_loans):
 @pytest.fixture()
 def mock_is_item_available_for_checkout():
     """Mock item_available check."""
-    path = \
-        "invenio_circulation.api.is_item_available_for_checkout"
+    path = "invenio_circulation.api.is_item_available_for_checkout"
     with mock.patch(path) as mock_is_item_available_for_checkout:
         mock_is_item_available_for_checkout.return_value = False
         yield mock_is_item_available_for_checkout
@@ -176,8 +173,7 @@ def mock_is_item_available_for_checkout():
 @pytest.fixture()
 def mock_is_item_at_desk_available_for_checkout():
     """Mock item_at_desk_available check."""
-    path = \
-        "invenio_circulation.api.is_item_at_desk_available_for_checkout"
+    path = "invenio_circulation.api.is_item_at_desk_available_for_checkout"
     with mock.patch(path) as mock_is_item_at_desk_available_for_checkout:
         mock_is_item_at_desk_available_for_checkout.return_value = False
         yield mock_is_item_at_desk_available_for_checkout
@@ -186,9 +182,7 @@ def mock_is_item_at_desk_available_for_checkout():
 @pytest.fixture()
 def mock_get_pending_loans_by_doc_pid():
     """Mock item_available check."""
-    path = \
-        "invenio_circulation.transitions.transitions" \
-        ".get_pending_loans_by_doc_pid"
+    path = "invenio_circulation.transitions.transitions" ".get_pending_loans_by_doc_pid"
     # assert path exists
     with mock.patch(path) as mock_get_pending_loans_by_doc_pid:
         mock_get_pending_loans_by_doc_pid.return_value = False
@@ -198,9 +192,10 @@ def mock_get_pending_loans_by_doc_pid():
 @pytest.fixture()
 def mock_ensure_item_is_available_for_checkout():
     """Mock ensure_item_is_available_for_checkout."""
-    path = \
-        "invenio_circulation.transitions.base.Transition" \
+    path = (
+        "invenio_circulation.transitions.base.Transition"
         ".ensure_item_is_available_for_checkout"
+    )
     with mock.patch(path) as mock_ensure_item_is_available_for_checkout:
         yield mock_ensure_item_is_available_for_checkout
 
@@ -213,9 +208,9 @@ def users(db, base_app):
     db.session.execute("ALTER SEQUENCE IF EXISTS accounts_user_id_seq RESTART")
     db.session.commit()
 
-    base_app.config[
-        "CIRCULATION_VIEWS_PERMISSIONS_FACTORY"
-    ] = test_views_permissions_factory
+    base_app.config["CIRCULATION_VIEWS_PERMISSIONS_FACTORY"] = (
+        test_views_permissions_factory
+    )
 
     with db.session.begin_nested():
         datastore = base_app.extensions["security"].datastore
@@ -233,15 +228,11 @@ def users(db, base_app):
 
         # Give role to admin
         admin_role = Role(name="admin")
-        db.session.add(
-            ActionRoles(action=superuser_access.value, role=admin_role)
-        )
+        db.session.add(ActionRoles(action=superuser_access.value, role=admin_role))
         datastore.add_role_to_user(admin, admin_role)
         # Give role to user
         manager_role = Role(name="manager")
-        db.session.add(
-            ActionRoles(action=loan_read_access.value, role=manager_role)
-        )
+        db.session.add(ActionRoles(action=loan_read_access.value, role=manager_role))
         datastore.add_role_to_user(manager, manager_role)
     db.session.commit()
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,15 +51,13 @@ class SwappedNestedConfig:
 
     def __enter__(self):
         """Save previous value and swap it with the new."""
-        config_obj = reduce(dict.__getitem__, self.nested_keys[:-1],
-                            current_app.config)
+        config_obj = reduce(dict.__getitem__, self.nested_keys[:-1], current_app.config)
         self.prev_value = config_obj[self.nested_keys[-1]]
         config_obj[self.nested_keys[-1]] = self.new_value
 
     def __exit__(self, type, value, traceback):
         """Restore previous value."""
-        config_obj = reduce(dict.__getitem__, self.nested_keys[:-1],
-                            current_app.config)
+        config_obj = reduce(dict.__getitem__, self.nested_keys[:-1], current_app.config)
         config_obj[self.nested_keys[-1]] = self.prev_value
 
 
@@ -75,7 +73,7 @@ def create_loan(data):
 
 def test_views_permissions_factory(action):
     """Test views permissions factory."""
-    if action == 'loan-read-access':
+    if action == "loan-read-access":
         return has_read_loan_permission()
     else:
         return deny_all()

--- a/tests/test_api_loan_status_item_pid.py
+++ b/tests/test_api_loan_status_item_pid.py
@@ -20,30 +20,21 @@ from .helpers import create_loan
 
 def test_api_circulation_item_loan_pending(app, indexed_loans):
     """Test that no Loan is returned for the given Item if only pendings."""
-    pending_item_pid = {
-      "type": "itemid",
-      "value": "item_pending_1"
-    }
+    pending_item_pid = {"type": "itemid", "value": "item_pending_1"}
     loan = get_loan_for_item(pending_item_pid)
     assert loan is None
 
 
 def test_api_circulation_item_no_loan(app, indexed_loans):
     """Test that no Loan is returned for the given Item if no loans."""
-    not_loaned_item_pid = {
-      "type": "itemid",
-      "value": "item_not_loaned"
-    }
+    not_loaned_item_pid = {"type": "itemid", "value": "item_not_loaned"}
     loan = get_loan_for_item(not_loaned_item_pid)
     assert loan is None
 
 
 def test_api_circulation_item_on_loan(app, indexed_loans):
     """Test that Loan is returned for the given Item if one active."""
-    multiple_loans_pid = {
-      "type": "itemid",
-      "value": "item_multiple_pending_on_loan_7"
-    }
+    multiple_loans_pid = {"type": "itemid", "value": "item_multiple_pending_on_loan_7"}
     loan = get_loan_for_item(multiple_loans_pid)
     assert loan["state"] == "ITEM_ON_LOAN"
     assert loan["item_pid"] == multiple_loans_pid
@@ -57,10 +48,7 @@ def test_api_circulation_item_not_found(app, indexed_loans):
 
 def test_multiple_active_loans(app, db, indexed_loans):
     """Test that raises if there are multiple active Loans for given Item."""
-    multiple_loans_pid = {
-      "type": "itemid",
-      "value": "item_multiple_pending_on_loan_7"
-    }
+    multiple_loans_pid = {"type": "itemid", "value": "item_multiple_pending_on_loan_7"}
 
     test_loan_data = {
         "item_pid": {

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -27,7 +27,7 @@ from invenio_circulation.errors import (
 
 def test_not_implemented(app):
     """Test NotImplementedConfigurationError."""
-    config_variable = 'CONFIG_VAR'
+    config_variable = "CONFIG_VAR"
     msg = (
         "Function is not implemented. Implement this function in your module "
         "and pass it to the config variable '{}'".format(config_variable)
@@ -40,7 +40,7 @@ def test_not_implemented(app):
 
 def test_invalid_permission(app):
     """Test InvalidPermissionError."""
-    permission = 'simple_user'
+    permission = "simple_user"
     msg = "This action is not permitted for your role '{}'".format(permission)
     with pytest.raises(InvalidPermissionError) as ex:
         raise InvalidPermissionError(permission=permission)
@@ -50,12 +50,11 @@ def test_invalid_permission(app):
 
 def test_record_cannot_be_requested(app):
     """Test record cannot be requested."""
-    state = 'loan_state'
-    item_pid = 'item_pid'
-    msg = (
-        'Transition to {0} failed.'
-        'Document {1} can not be requested.'
-    ).format(state, item_pid)
+    state = "loan_state"
+    item_pid = "item_pid"
+    msg = ("Transition to {0} failed." "Document {1} can not be requested.").format(
+        state, item_pid
+    )
 
     with pytest.raises(RecordCannotBeRequestedError) as ex:
         raise RecordCannotBeRequestedError(description=msg)
@@ -67,9 +66,12 @@ def test_item_not_available(app):
     """Test item not available."""
     item_pid = dict(type="itemid", value="1")
     transition = "checkout"
-    msg = "The item requested with PID '{0}:{1}' is not available. " \
-          "Transition to '{2}' has failed." \
-        .format(item_pid["type"], item_pid["value"], transition)
+    msg = (
+        "The item requested with PID '{0}:{1}' is not available. "
+        "Transition to '{2}' has failed.".format(
+            item_pid["type"], item_pid["value"], transition
+        )
+    )
     with pytest.raises(ItemNotAvailableError) as ex:
         raise ItemNotAvailableError(item_pid=item_pid, transition=transition)
 
@@ -80,8 +82,9 @@ def test_item_not_available(app):
 def test_multiple_loans_on_item(app):
     """Test multiple loans on item."""
     item_pid = dict(type="itemid", value="1")
-    msg = "Multiple active loans on item with PID '{0}:{1}'" \
-        .format(item_pid["type"], item_pid["value"])
+    msg = "Multiple active loans on item with PID '{0}:{1}'".format(
+        item_pid["type"], item_pid["value"]
+    )
     with pytest.raises(MultipleLoansOnItemError) as ex:
         raise MultipleLoansOnItemError(item_pid=item_pid)
 
@@ -150,9 +153,6 @@ def test_loan_max_extensions(app):
         "for loan '{}'".format(extension_count, loan_pid)
     )
     with pytest.raises(LoanMaxExtensionError) as ex:
-        raise LoanMaxExtensionError(
-            loan_pid=loan_pid,
-            extension_count=extension_count
-        )
+        raise LoanMaxExtensionError(loan_pid=loan_pid, extension_count=extension_count)
     assert ex.value.code == 400
     assert ex.value.description == msg

--- a/tests/test_loan_record.py
+++ b/tests/test_loan_record.py
@@ -18,7 +18,7 @@ def test_state_checkout_with_loan_pid(
 ):
     """Test that created Loan validates after a checkout action."""
     new_params = deepcopy(params)
-    new_params['trigger'] = 'checkout'
+    new_params["trigger"] = "checkout"
     loan = current_circulation.circulation.trigger(loan_created, **new_params)
     loan.validate()
 

--- a/tests/test_loan_search.py
+++ b/tests/test_loan_search.py
@@ -24,11 +24,7 @@ def _assert_total(total, expected):
 def test_search_loans_by_pid(indexed_loans):
     """Test retrieve loan list belonging to an item."""
     item_pid = dict(type="itemid", value="item_pending_1")
-    loans = list(
-        search_by_pid(
-            item_pid=item_pid
-        ).scan()
-    )
+    loans = list(search_by_pid(item_pid=item_pid).scan())
     assert len(loans) == 1
     loan = Loan.get_record_by_pid(loans[0]["pid"])
     assert loan["item_pid"] == item_pid
@@ -99,9 +95,7 @@ def test_search_loans_by_patron_and_item_or_document(indexed_loans):
     _assert_total(search_result.hits.total, 0)
 
 
-def test_search_loans_by_patron_and_item_or_document_filtering_states(
-    indexed_loans
-):
+def test_search_loans_by_patron_and_item_or_document_filtering_states(indexed_loans):
     """Test retrieve loan list by patron and items filtering states."""
     search = search_by_patron_item_or_document(
         patron_pid="1",

--- a/tests/test_loan_transition_created_to_pending.py
+++ b/tests/test_loan_transition_created_to_pending.py
@@ -117,11 +117,10 @@ def test_auto_assignment_of_returned_item_to_pending_document_requests(
     with SwappedConfig(
         "CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM", lambda x: "document_pid"
     ):
-        with SwappedConfig(
-            "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "loc_pid"
-        ):
+        with SwappedConfig("CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "loc_pid"):
             with SwappedConfig(
-                    "CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True):
+                "CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True
+            ):
                 # start a loan on item with pid 'item_pid'
                 new_loan = current_circulation.circulation.trigger(
                     loan_created,
@@ -170,7 +169,5 @@ def test_auto_assignment_of_returned_item_to_pending_document_requests(
                 # item `item_pid` has been attached to pending loan request on
                 # `document_pid` automatically
                 assert pending_loan["state"] == "PENDING"
-                assert pending_loan["item_pid"] == dict(
-                    type="itemid", value="item_pid"
-                )
+                assert pending_loan["item_pid"] == dict(type="itemid", value="item_pid")
                 assert pending_loan["document_pid"] == "document_pid"

--- a/tests/test_loan_transition_item_on_loan_to_item_returned.py
+++ b/tests/test_loan_transition_item_on_loan_to_item_returned.py
@@ -13,9 +13,7 @@ from invenio_circulation.proxies import current_circulation
 from .helpers import SwappedConfig
 
 
-def test_item_on_loan_to_item_in_transit_to_house(
-    loan_created, db, params
-):
+def test_item_on_loan_to_item_in_transit_to_house(loan_created, db, params):
     """Test transition from ITEM_ON_LOAN to ITEM_IN_TRANSIT_TO_HOUSE state."""
     loan = current_circulation.circulation.trigger(
         loan_created,
@@ -33,16 +31,12 @@ def test_item_on_loan_to_item_in_transit_to_house(
     with SwappedConfig(
         "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "other_location_pid"
     ):
-        loan = current_circulation.circulation.trigger(
-            loan, **dict(params)
-        )
+        loan = current_circulation.circulation.trigger(loan, **dict(params))
 
         assert loan["state"] == "ITEM_IN_TRANSIT_TO_HOUSE"
 
 
-def test_item_on_loan_to_item_returned_same_location(
-    loan_created, db, params
-):
+def test_item_on_loan_to_item_returned_same_location(loan_created, db, params):
     """Test transition from ITEM_ON_LOAN to ITEM_RETURNED state."""
     loan = current_circulation.circulation.trigger(
         loan_created,
@@ -57,12 +51,7 @@ def test_item_on_loan_to_item_returned_same_location(
     assert loan["transaction_location_pid"] == "loc_pid"
 
     # item is returned to the same location
-    with SwappedConfig(
-        "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "loc_pid"
-    ):
-        with SwappedConfig(
-                "CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True):
-            loan = current_circulation.circulation.trigger(
-                loan, **dict(params)
-            )
+    with SwappedConfig("CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "loc_pid"):
+        with SwappedConfig("CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True):
+            loan = current_circulation.circulation.trigger(loan, **dict(params))
             assert loan["state"] == "ITEM_RETURNED"

--- a/tests/test_loan_transition_pending_to_item_at_desk_or_transit.py
+++ b/tests/test_loan_transition_pending_to_item_at_desk_or_transit.py
@@ -20,8 +20,7 @@ from invenio_circulation.utils import validate_item_pickup_transaction_locations
 from .helpers import SwappedConfig
 
 
-def test_validate_pickup_transaction_locations_not_implemented(
-        loan_created, params):
+def test_validate_pickup_transaction_locations_not_implemented(loan_created, params):
     """Test transition from PENDING to ITEM_AT_DESK.
 
     when the method validate_item_pickup_transaction_locations is not
@@ -40,12 +39,9 @@ def test_validate_pickup_transaction_locations_not_implemented(
     with pytest.raises(NotImplementedConfigurationError):
         with SwappedConfig(
             "CIRCULATION_LOAN_LOCATIONS_VERIFICATIONS",
-                validate_item_pickup_transaction_locations(
-                    loan, "ITEM_AT_DESK")
+            validate_item_pickup_transaction_locations(loan, "ITEM_AT_DESK"),
         ):
-            loan = current_circulation.circulation.trigger(
-                loan, **dict(params)
-            )
+            loan = current_circulation.circulation.trigger(loan, **dict(params))
 
 
 def test_validate_item_at_desk(loan_created, params):
@@ -64,9 +60,7 @@ def test_validate_item_at_desk(loan_created, params):
     with SwappedConfig(
         "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
-        loan = current_circulation.circulation.trigger(
-            loan, **dict(params)
-        )
+        loan = current_circulation.circulation.trigger(loan, **dict(params))
         assert loan["state"] == "ITEM_AT_DESK"
 
 
@@ -87,8 +81,7 @@ def test_validate_item_in_transit_pickup(loan_created, params):
         "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
         loan = current_circulation.circulation.trigger(
-            loan, **dict(params,
-                         pickup_location_pid="other_location_pid")
+            loan, **dict(params, pickup_location_pid="other_location_pid")
         )
         assert loan["state"] == "ITEM_IN_TRANSIT_FOR_PICKUP"
 
@@ -98,9 +91,7 @@ def test_checkout_without_item_attached(loan_created, params):
 
     assert loan_created["state"] == "CREATED"
 
-    with SwappedConfig(
-        "CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT", lambda x: []
-    ):
+    with SwappedConfig("CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT", lambda x: []):
         loan = current_circulation.circulation.trigger(
             loan_created, **dict(params, trigger="request")
         )
@@ -127,8 +118,8 @@ def test_checkout_with_different_pickup_location(loan_created, params):
         "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
         loan = current_circulation.circulation.trigger(
-            loan_created, **dict(params, trigger="request",
-                                 pickup_location_pid="pickup_location_pid")
+            loan_created,
+            **dict(params, trigger="request", pickup_location_pid="pickup_location_pid")
         )
 
         assert loan["item_pid"] == dict(type="itemid", value="item_pid")
@@ -136,8 +127,8 @@ def test_checkout_with_different_pickup_location(loan_created, params):
         assert loan["state"] == "PENDING"
 
         current_circulation.circulation.trigger(
-            loan, **dict(params, trigger="next",
-                         pickup_location_pid="other_location_pid")
+            loan,
+            **dict(params, trigger="next", pickup_location_pid="other_location_pid")
         )
 
         assert loan["state"] == "ITEM_IN_TRANSIT_FOR_PICKUP"
@@ -152,8 +143,8 @@ def test_checkout_with_same_pickup_location(loan_created, params):
         "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
         loan = current_circulation.circulation.trigger(
-            loan_created, **dict(params, trigger="request",
-                                 pickup_location_pid="pickup_location_pid")
+            loan_created,
+            **dict(params, trigger="request", pickup_location_pid="pickup_location_pid")
         )
 
         assert loan["item_pid"] == dict(type="itemid", value="item_pid")
@@ -161,8 +152,8 @@ def test_checkout_with_same_pickup_location(loan_created, params):
         assert loan["state"] == "PENDING"
 
         current_circulation.circulation.trigger(
-            loan, **dict(params, trigger="next",
-                         pickup_location_pid="pickup_location_pid")
+            loan,
+            **dict(params, trigger="next", pickup_location_pid="pickup_location_pid")
         )
 
         assert loan["state"] == "ITEM_AT_DESK"

--- a/tests/test_loan_transition_to_item_on_loan.py
+++ b/tests/test_loan_transition_to_item_on_loan.py
@@ -32,8 +32,7 @@ def test_created_to_item_on_loan_available_item_with_default_location(
     assert loan_created["state"] == "CREATED"
 
     with SwappedConfig(
-        "CIRCULATION_ITEM_LOCATION_RETRIEVER",
-        lambda x: "pickup_location_pid"
+        "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
         loan = current_circulation.circulation.trigger(
             loan_created, **dict(params, trigger="checkout")
@@ -54,12 +53,11 @@ def test_created_to_item_on_loan_available_item_with_specified_location(
     assert loan_created["state"] == "CREATED"
 
     with SwappedConfig(
-        "CIRCULATION_ITEM_LOCATION_RETRIEVER",
-        lambda x: "pickup_location_pid"
+        "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
         loan = current_circulation.circulation.trigger(
-            loan_created, **dict(params, trigger="checkout",
-                                 pickup_location_pid="other_location_pid")
+            loan_created,
+            **dict(params, trigger="checkout", pickup_location_pid="other_location_pid")
         )
 
     assert loan["state"] == "ITEM_ON_LOAN"
@@ -74,18 +72,19 @@ def test_created_to_item_on_loan_unavailable_item(
 
     assert loan_created["state"] == "CREATED"
 
-    mock_ensure_item_is_available_for_checkout.side_effect = \
-        ItemNotAvailableError(item_pid=dict(type="itemid", value="1"),
-                              transition="Fake Transition")
+    mock_ensure_item_is_available_for_checkout.side_effect = ItemNotAvailableError(
+        item_pid=dict(type="itemid", value="1"), transition="Fake Transition"
+    )
 
     with pytest.raises(ItemNotAvailableError):
         with SwappedConfig(
-            "CIRCULATION_ITEM_LOCATION_RETRIEVER",
-            lambda x: "pickup_location_pid"
+            "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
         ):
             current_circulation.circulation.trigger(
-                loan_created, **dict(params, trigger="checkout",
-                                     pickup_location_pid="other_location_pid")
+                loan_created,
+                **dict(
+                    params, trigger="checkout", pickup_location_pid="other_location_pid"
+                )
             )
 
 
@@ -103,8 +102,7 @@ def test_created_to_item_on_loan_available_item_with_invalid_duration(
 
     with pytest.raises(TransitionConstraintsViolationError):
         with SwappedConfig(
-            "CIRCULATION_ITEM_LOCATION_RETRIEVER",
-            lambda x: "pickup_location_pid"
+            "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
         ):
             current_circulation.circulation.trigger(
                 loan_created, **dict(params, trigger="checkout")
@@ -125,8 +123,7 @@ def test_created_to_item_on_loan_available_item_with_valid_duration(
     params["end_date"] = params["start_date"] + timedelta(days=59)
 
     with SwappedConfig(
-        "CIRCULATION_ITEM_LOCATION_RETRIEVER",
-        lambda x: "pickup_location_pid"
+        "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
         loan = current_circulation.circulation.trigger(
             loan_created, **dict(params, trigger="checkout")
@@ -146,8 +143,7 @@ def test_pending_to_item_on_loan_available_item(
     mock_ensure_item_is_available_for_checkout.side_effect = None
 
     with SwappedConfig(
-        "CIRCULATION_ITEM_LOCATION_RETRIEVER",
-        lambda x: "pickup_location_pid"
+        "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
         loan = current_circulation.circulation.trigger(
             loan_created, **dict(params, trigger="request")
@@ -156,8 +152,8 @@ def test_pending_to_item_on_loan_available_item(
         assert loan["state"] == "PENDING"
 
         loan = current_circulation.circulation.trigger(
-            loan_created, **dict(params, trigger="checkout",
-                                 pickup_location_pid="other_location_pid")
+            loan_created,
+            **dict(params, trigger="checkout", pickup_location_pid="other_location_pid")
         )
 
         assert loan["state"] == "ITEM_ON_LOAN"

--- a/tests/test_loan_transitions.py
+++ b/tests/test_loan_transitions.py
@@ -74,13 +74,9 @@ def test_loan_checkout_checkin(
 
     # set same transaction location to avoid "in transit"
     same_location = params["transaction_location_pid"]
-    with SwappedConfig(
-        "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: same_location
-    ):
-        with SwappedConfig(
-                "CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True):
-            loan = current_circulation.circulation.trigger(
-                loan, **dict(params))
+    with SwappedConfig("CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: same_location):
+        with SwappedConfig("CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True):
+            loan = current_circulation.circulation.trigger(loan, **dict(params))
             assert loan["state"] == "ITEM_RETURNED"
             # Keep changes in database to make item available for checkout
             # later
@@ -131,9 +127,7 @@ def test_can_change_item_and_loc_pid_before_checkout(
         )
         db.session.commit()
         assert changed_loan["state"] == "ITEM_IN_TRANSIT_FOR_PICKUP"
-        assert changed_loan["item_pid"] == dict(
-            type="itemid", value="other_item_pid_1"
-        )
+        assert changed_loan["item_pid"] == dict(type="itemid", value="other_item_pid_1")
         assert changed_loan["pickup_location_pid"] == "other_location_pid_1"
 
         changed_loan = copy.deepcopy(loan)
@@ -147,9 +141,7 @@ def test_can_change_item_and_loc_pid_before_checkout(
         )
         db.session.commit()
         assert changed_loan["state"] == "ITEM_AT_DESK"
-        assert changed_loan["item_pid"] == dict(
-            type="itemid", value="other_item_pid_2"
-        )
+        assert changed_loan["item_pid"] == dict(type="itemid", value="other_item_pid_2")
         assert changed_loan["pickup_location_pid"] == "pickup_location_pid"
 
         changed_loan = copy.deepcopy(loan)
@@ -164,9 +156,7 @@ def test_can_change_item_and_loc_pid_before_checkout(
         )
         db.session.commit()
         assert changed_loan["state"] == "ITEM_ON_LOAN"
-        assert changed_loan["item_pid"] == dict(
-            type="itemid", value="other_item_pid_3"
-        )
+        assert changed_loan["item_pid"] == dict(type="itemid", value="other_item_pid_3")
         assert changed_loan["pickup_location_pid"] == "other_location_pid_3"
 
 
@@ -236,9 +226,7 @@ def test_cannot_change_item_pid_after_checkout(
             )
 
 
-def test_loan_extend(
-    loan_created, params, mock_ensure_item_is_available_for_checkout
-):
+def test_loan_extend(loan_created, params, mock_ensure_item_is_available_for_checkout):
     """Test loan extend action."""
 
     mock_ensure_item_is_available_for_checkout.side_effect = None
@@ -496,13 +484,9 @@ def test_checkin_end_date_is_transaction_date(
     same_location = params["transaction_location_pid"]
     params["transaction_date"] = arrow.utcnow()
     new_transaction_date = params["transaction_date"]
-    with SwappedConfig(
-        "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: same_location
-    ):
-        with SwappedConfig(
-                "CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True):
-            loan = current_circulation.circulation.trigger(
-                loan, **dict(params))
+    with SwappedConfig("CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: same_location):
+        with SwappedConfig("CIRCULATION_SAME_LOCATION_VALIDATOR", lambda x, y: True):
+            loan = current_circulation.circulation.trigger(loan, **dict(params))
 
     assert loan["state"] == "ITEM_RETURNED"
     expected_end_date = str2datetime(new_transaction_date).date().isoformat()
@@ -529,17 +513,14 @@ def test_item_availability(indexed_loans):
     assert is_item_available_for_checkout(
         item_pid=dict(type="itemid", value="item_returned_6")
     )
-    assert is_item_available_for_checkout(
-        item_pid=dict(type="itemid", value="no_loan")
-    )
+    assert is_item_available_for_checkout(item_pid=dict(type="itemid", value="no_loan"))
     # item is not available because it has a loan with state ITEM_AT_DESK
     assert not is_item_available_for_checkout(
         item_pid=dict(type="itemid", value="item_at_desk_5")
     )
     # item is available because the checked-out patron owns the active loan
     assert is_item_at_desk_available_for_checkout(
-            item_pid=dict(type="itemid", value="item_at_desk_5"),
-            patron_pid="1"
+        item_pid=dict(type="itemid", value="item_at_desk_5"), patron_pid="1"
     )
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -18,17 +18,17 @@ from invenio_circulation.transitions.transitions import CreatedToPending
 def test_valid_permission(loan_created, params):
     """Test transition with valid permission."""
     transition = CreatedToPending(
-        'CREATED', 'PENDING', trigger='next', permission_factory=allow_all
+        "CREATED", "PENDING", trigger="next", permission_factory=allow_all
     )
     transition.execute(loan_created, **params)
-    assert loan_created['state'] == 'PENDING'
+    assert loan_created["state"] == "PENDING"
 
 
 def test_invalid_permission(loan_created, params):
     """Test transition without permission."""
     transition = CreatedToPending(
-        'CREATED', 'PENDING', trigger='next', permission_factory=deny_all
+        "CREATED", "PENDING", trigger="next", permission_factory=deny_all
     )
     with pytest.raises(InvalidPermissionError):
         transition.execute(loan_created, **params)
-    assert loan_created['state'] == 'CREATED'
+    assert loan_created["state"] == "CREATED"

--- a/tests/test_rest_loan_item.py
+++ b/tests/test_rest_loan_item.py
@@ -21,82 +21,77 @@ def test_rest_get_loan(app, json_headers, loan_created):
     """Test API GET call to fetch a loan by PID."""
     loan_pid = loan_pid_fetcher(loan_created.id, loan_created)
     expected_links = {
-        'actions': {
-            'request': build_url_action_for_pid(loan_pid, 'request'),
-            'checkout': build_url_action_for_pid(loan_pid, 'checkout')
+        "actions": {
+            "request": build_url_action_for_pid(loan_pid, "request"),
+            "checkout": build_url_action_for_pid(loan_pid, "checkout"),
         }
     }
 
     with app.test_client() as client:
-        url = url_for('invenio_records_rest.loanid_item',
-                      pid_value=loan_pid.pid_value)
+        url = url_for("invenio_records_rest.loanid_item", pid_value=loan_pid.pid_value)
         res = client.get(url, headers=json_headers)
 
     assert res.status_code == 200
-    loan_dict = json.loads(res.data.decode('utf-8'))
-    assert loan_dict['metadata']['state'] == loan_created['state']
-    assert loan_dict['links'] == expected_links
+    loan_dict = json.loads(res.data.decode("utf-8"))
+    assert loan_dict["metadata"]["state"] == loan_created["state"]
+    assert loan_dict["links"] == expected_links
 
 
 def _post(app, json_headers, params, pid_value, action):
     """Perform API POST with the given param."""
     with app.test_client() as client:
-        url = url_for('invenio_circulation_loan_actions.loanid_actions',
-                      pid_value=pid_value, action=action)
+        url = url_for(
+            "invenio_circulation_loan_actions.loanid_actions",
+            pid_value=pid_value,
+            action=action,
+        )
         res = client.post(url, headers=json_headers, data=json.dumps(params))
-        payload = json.loads(res.data.decode('utf-8'))
+        payload = json.loads(res.data.decode("utf-8"))
     return res, payload
 
 
-def test_rest_explicit_loan_valid_action(
-    app, json_headers, params, loan_created
-):
+def test_rest_explicit_loan_valid_action(app, json_headers, params, loan_created):
     """Test API valid action on loan."""
     loan_pid = loan_pid_fetcher(loan_created.id, loan_created)
 
-    res, payload = _post(app, json_headers, params,
-                         pid_value=loan_pid.pid_value, action='checkout')
+    res, payload = _post(
+        app, json_headers, params, pid_value=loan_pid.pid_value, action="checkout"
+    )
     assert res.status_code == 202
-    assert payload['metadata']['state'] == 'ITEM_ON_LOAN'
+    assert payload["metadata"]["state"] == "ITEM_ON_LOAN"
 
 
-def test_rest_automatic_loan_valid_action(
-    app, json_headers, params, loan_created
-):
+def test_rest_automatic_loan_valid_action(app, json_headers, params, loan_created):
     """Test API valid action on loan."""
     loan = current_circulation.circulation.trigger(
         loan_created,
-        **dict(params, trigger='request',
-               pickup_location_pid='pickup_location_pid')
+        **dict(params, trigger="request", pickup_location_pid="pickup_location_pid")
     )
-    assert loan['state'] == 'PENDING'
+    assert loan["state"] == "PENDING"
 
-    app.config[
-        'CIRCULATION_ITEM_LOCATION_RETRIEVER'
-    ] = lambda x: 'pickup_location_pid'
+    app.config["CIRCULATION_ITEM_LOCATION_RETRIEVER"] = lambda x: "pickup_location_pid"
 
     loan_pid = loan_pid_fetcher(loan.id, loan)
 
-    res, payload = _post(app, json_headers, params,
-                         pid_value=loan_pid.pid_value, action='next')
+    res, payload = _post(
+        app, json_headers, params, pid_value=loan_pid.pid_value, action="next"
+    )
     assert res.status_code == 202
-    assert payload['metadata']['state'] == 'ITEM_AT_DESK'
+    assert payload["metadata"]["state"] == "ITEM_AT_DESK"
 
 
-def test_rest_loan_invalid_action(
-    app, json_headers, params, loan_created
-):
+def test_rest_loan_invalid_action(app, json_headers, params, loan_created):
     """Test API invalid action on loan."""
     loan = current_circulation.circulation.trigger(
         loan_created,
-        **dict(params, trigger='request',
-               pickup_location_pid='pickup_location_pid')
+        **dict(params, trigger="request", pickup_location_pid="pickup_location_pid")
     )
-    assert loan['state'] == 'PENDING'
+    assert loan["state"] == "PENDING"
 
     loan_pid = loan_pid_fetcher(loan.id, loan)
 
-    res, payload = _post(app, json_headers, params,
-                         pid_value=loan_pid.pid_value, action='extend')
+    res, payload = _post(
+        app, json_headers, params, pid_value=loan_pid.pid_value, action="extend"
+    )
     assert res.status_code == 400
-    assert 'message' in payload
+    assert "message" in payload

--- a/tests/test_rest_serializers.py
+++ b/tests/test_rest_serializers.py
@@ -33,37 +33,33 @@ def test_rest_loader_valid_params(app, json_headers):
             transaction_location_pid="loc_pid",
             transaction_user_pid="user_pid",
             start_date=start_date.date().isoformat(),
-            end_date=end_date.date().isoformat()
+            end_date=end_date.date().isoformat(),
         )
-        res = client.post(
-            url, data=json.dumps(params), headers=json_headers
-        )
+        res = client.post(url, data=json.dumps(params), headers=json_headers)
         assert res.status_code == 201
         loan = res.get_json()
-        assert loan['metadata']['transaction_date'] == now.isoformat()
+        assert loan["metadata"]["transaction_date"] == now.isoformat()
 
-        url = url_for("invenio_records_rest.loanid_item", pid_value='1')
+        url = url_for("invenio_records_rest.loanid_item", pid_value="1")
         res = client.get(url, headers=json_headers)
         assert res.status_code == 200
         loan = res.get_json()
-        assert loan['metadata']['transaction_date'] == now.isoformat()
+        assert loan["metadata"]["transaction_date"] == now.isoformat()
 
 
 @pytest.mark.parametrize(
     "invalid_params",
     [
-        {"transaction_date": arrow.utcnow().format('YYYY-MM-DD')},
-        {"transaction_date": arrow.utcnow().to('US/Pacific').isoformat()},
+        {"transaction_date": arrow.utcnow().format("YYYY-MM-DD")},
+        {"transaction_date": arrow.utcnow().to("US/Pacific").isoformat()},
         {"start_date": arrow.utcnow().isoformat()},
         {"end_date": arrow.utcnow().isoformat()},
         {"request_expire_date": arrow.utcnow().isoformat()},
         {"item_pid": dict(value="1")},
-        {"item_pid": dict(type="itemid")}
-    ]
+        {"item_pid": dict(type="itemid")},
+    ],
 )
-def test_rest_loader_invalid_transaction_date_format(
-    app, json_headers, invalid_params
-):
+def test_rest_loader_invalid_transaction_date_format(app, json_headers, invalid_params):
     """Test rest loader transaction_date format validation."""
 
     with app.test_client() as client:
@@ -75,9 +71,7 @@ def test_rest_loader_invalid_transaction_date_format(
             transaction_user_pid="user_pid",
             **invalid_params
         )
-        res = client.post(
-            url, data=json.dumps(params), headers=json_headers
-        )
+        res = client.post(url, data=json.dumps(params), headers=json_headers)
         assert res.status_code == 400
         response = res.get_json()
-        assert response['message'] == "Validation error."
+        assert response["message"] == "Validation error."

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -55,9 +55,7 @@ def test_signals_loan_extend(loan_created, params):
     assert updated_loan["state"] == "ITEM_ON_LOAN"
     assert trigger == "checkout"
 
-    current_circulation.circulation.trigger(
-        loan, **dict(params, trigger="extend")
-    )
+    current_circulation.circulation.trigger(loan, **dict(params, trigger="extend"))
     assert len(recorded) == 1
     initial_loan, updated_loan, trigger, kwargs = recorded.pop()
     assert initial_loan["state"] == "ITEM_ON_LOAN"

--- a/tests/test_transition_item_at_desk_to_item_on_loan.py
+++ b/tests/test_transition_item_at_desk_to_item_on_loan.py
@@ -34,14 +34,10 @@ def test_checkout_from_item_at_desk_valid_duration(loan_created, params):
     with SwappedConfig(
         "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
-        loan = current_circulation.circulation.trigger(
-            loan, **dict(params)
-        )
+        loan = current_circulation.circulation.trigger(loan, **dict(params))
         assert loan["state"] == "ITEM_AT_DESK"
 
-        loan = current_circulation.circulation.trigger(
-            loan, **dict(params)
-        )
+        loan = current_circulation.circulation.trigger(loan, **dict(params))
 
         assert loan["state"] == "ITEM_ON_LOAN"
 
@@ -61,9 +57,7 @@ def test_checkout_from_item_at_desk_invalid_duration(loan_created, params):
     with SwappedConfig(
         "CIRCULATION_ITEM_LOCATION_RETRIEVER", lambda x: "pickup_location_pid"
     ):
-        loan = current_circulation.circulation.trigger(
-            loan, **dict(params)
-        )
+        loan = current_circulation.circulation.trigger(loan, **dict(params))
         assert loan["state"] == "ITEM_AT_DESK"
 
         now = arrow.utcnow()
@@ -72,6 +66,4 @@ def test_checkout_from_item_at_desk_invalid_duration(loan_created, params):
         loan["end_date"] = end_date.date().isoformat()
 
         with pytest.raises(TransitionConstraintsViolationError):
-            current_circulation.circulation.trigger(
-                loan, **dict(params)
-            )
+            current_circulation.circulation.trigger(loan, **dict(params))


### PR DESCRIPTION
*  format code with black
* make first parameter of loan_state_changed signal the current_object (required for [this](https://github.com/CERNDocumentServer/cds-ils/issues/1029))
* add `extra_data` property to loan mapping  (required for [this](https://github.com/CERNDocumentServer/cds-ils/issues/1029))
* fix test CI
   * drop support for postgresql13


closes: https://github.com/CERNDocumentServer/cds-ils/issues/1029

